### PR TITLE
Handle csv escaping

### DIFF
--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
@@ -1,6 +1,7 @@
 package ebi.spot.neo4j2owl.importer;
 
 import ebi.spot.neo4j2owl.exporter.N2OException;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.codehaus.jackson.io.JsonStringEncoder;
 import org.semanticweb.owlapi.model.OWLEntity;
 
@@ -159,7 +160,7 @@ class N2OCSVWriter {
     private String csvCellValue(Object o) {
         // {\"X\":660,\"Y\":1290,\"Z\":382}
         //System.out.println("csvCellValue()");
-        String raw_value = o.toString();
+        String val = o.toString();
         //System.out.println(raw_value);
        /*
         String json = new String(JsonStringEncoder.getInstance().quoteAsString(raw_value));
@@ -170,9 +171,22 @@ class N2OCSVWriter {
         String val = json;
         */
         // see https://neo4j.com/developer/kb/space-in-import-filename-for-load-csv/
-        String val = raw_value.replaceAll("\"","\"\"");
+
         //
-        //System.out.println(val);
+            if (val.contains("\"")) {
+                //String orig = val;
+                val = val.replaceAll("(?<![\\\\])[\"]","\"\"");
+                val = val.replaceAll("[\\\\]+[\"]","\\\\\\\\\"\"");
+                /*
+                if(!orig.equals(val)) {
+                    System.out.println("**************");
+                    System.out.println(orig);
+                    System.out.println(val);
+                }
+                */
+        }
+
+
         return "\"" + val + "\"";
     }
 


### PR DESCRIPTION
The problem is, in essence, that both `""` and `\"` escape the `"` in the neo4j csv file. So when escaping for csv, this is what happened `\""` which confused neo4j CSV import. The solution here is that the occurrence of a string `\"` in the data is replaced by this: `\\""` -> then it roundtrips correctly. Test was added to account for this case.