### PR TITLE
No reasoning support

### DIFF
--- a/src/main/java/ebi/spot/neo4j2owl/importer/IRIManager.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/IRIManager.java
@@ -11,7 +11,7 @@ import org.semanticweb.owlapi.util.DefaultPrefixManager;
 import java.util.*;
 import java.util.regex.Pattern;
 
-class IRIManager {
+public class IRIManager {
 
     private final Pattern p = Pattern.compile("[a-zA-Z]+[_]+[0-9]+");
     private final Map<String,String> prefixNamespaceMap = new HashMap<>();
@@ -20,7 +20,7 @@ class IRIManager {
     private int NAMESPACECOUNTER = 0;
     private static N2OLog logger = N2OLog.getInstance();
 
-    IRIManager() {
+    public IRIManager() {
         addPrefixNamespacePair(N2OStatic.NEO4J_UNMAPPED_PROPERTY_PREFIX_URI, "n2oc");
         addPrefixNamespacePair(N2OStatic.NEO4J_BUILTIN_PROPERTY_PREFIX_URI, "n2o");
 

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportManager.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportManager.java
@@ -9,7 +9,7 @@ import org.semanticweb.owlapi.util.mansyntax.ManchesterOWLSyntaxParser;
 
 import java.util.*;
 
-class N2OImportManager {
+public class N2OImportManager {
     private final ManchesterOWLSyntaxParser parser = OWLManager.createManchesterParser();
     private final Map<String, Set<String>> prop_columns = new HashMap<>();
     private final Map<String, Set<String>> node_columns = new HashMap<>();
@@ -25,7 +25,7 @@ class N2OImportManager {
     private final OWLOntology o;
     //private long nextavailableid = 1;
 
-    N2OImportManager(OWLOntology o, IRIManager curies) {
+    public N2OImportManager(OWLOntology o, IRIManager curies) {
         this.curies = curies;
         Map<String,OWLEntity> entityMap = prepareEntityMap(o);
         parser.setOWLEntityChecker(new N2OEntityChecker(entityMap));
@@ -240,7 +240,7 @@ class N2OImportManager {
         return Optional.empty();
     }
 
-    OWLClassExpression parseExpression(String manchesterSyntaxString) {
+    public OWLClassExpression parseExpression(String manchesterSyntaxString) {
         parser.setStringToParse(manchesterSyntaxString);
         return parser.parseClassExpression();
     }

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportManager.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportManager.java
@@ -292,4 +292,8 @@ public class N2OImportManager {
     Map<String, Object> getRelationshipProperties(N2OOWLRelationship e) {
         return this.relationship_properties.get(e);
     }
+    
+    public Map<OWLEntity, Set<String>> getNodeLabels() {
+		return nodeLabels;
+	}
 }

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportService.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportService.java
@@ -24,15 +24,17 @@ public class N2OImportService {
         }
     }
 
-
-
     public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
+    	return prepareCSVFilesForImport(url, importdir, importResults, true);
+    }
+
+    public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults, Boolean enableReasoning) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
         logger.log("Loading Ontology");
         OWLOntology o = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(getOntologyIRI(url, importdir));
         logger.log("Size ontology: " + o.getAxiomCount());
 
         N2OOntologyLoader ontologyImporter = new N2OOntologyLoader();
-        ontologyImporter.importOntology(o, importResults);
+        ontologyImporter.importOntology(o, importResults, enableReasoning);
 
         logger.log("Loading in Database: " + importdir.getAbsolutePath());
 

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportService.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportService.java
@@ -25,16 +25,16 @@ public class N2OImportService {
     }
 
     public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
-    	return prepareCSVFilesForImport(url, importdir, importResults, true);
+    	return prepareCSVFilesForImport(url, importdir, importResults, true, null);
     }
 
-    public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults, Boolean enableReasoning) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
+    public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults, Boolean enableReasoning, String annotation_iri) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
         logger.log("Loading Ontology");
         OWLOntology o = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(getOntologyIRI(url, importdir));
         logger.log("Size ontology: " + o.getAxiomCount());
 
         N2OOntologyLoader ontologyImporter = new N2OOntologyLoader();
-        ontologyImporter.importOntology(o, importResults, enableReasoning);
+        ontologyImporter.importOntology(o, importResults, enableReasoning, annotation_iri);
 
         logger.log("Loading in Database: " + importdir.getAbsolutePath());
 

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImporterRunner.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImporterRunner.java
@@ -13,9 +13,11 @@ public class N2OImporterRunner {
 		String config = args[1];
 		File importdir = new File(args[2]);
 		Boolean enableReasoning = true;
+		String annotation_iri = null;
 
 		if (args.length > 3) {
 			enableReasoning = Boolean.parseBoolean(args[3]);
+			annotation_iri = args[4];
 		}
 
 		if (config.equals("none")) {
@@ -26,7 +28,7 @@ public class N2OImporterRunner {
 		N2OImportResult importResults = new N2OImportResult();
 		try {
 			importService.prepareConfig(config, importdir);
-			N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(url, importdir, importResults, enableReasoning);
+			N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(url, importdir, importResults, enableReasoning, annotation_iri);
 			File cypherDir = new File(importdir, "transactions");
 			if (!cypherDir.isDirectory()) {
 				boolean created = cypherDir.mkdir();

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImporterRunner.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImporterRunner.java
@@ -8,33 +8,39 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 public class N2OImporterRunner {
-    public static void main(String[] args) {
-        String url = args[0];
-        String config = args[1];
-        File importdir = new File(args[2]);
+	public static void main(String[] args) {
+		String url = args[0];
+		String config = args[1];
+		File importdir = new File(args[2]);
+		Boolean enableReasoning = true;
 
-        if(config.equals("none")) {
-            config = null;
-        }
+		if (args.length > 3) {
+			enableReasoning = Boolean.parseBoolean(args[3]);
+		}
 
-        N2OImportService importService = new N2OImportService();
-        N2OImportResult importResults = new N2OImportResult();
-        try {
-            importService.prepareConfig(config, importdir);
-            N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(url, importdir, importResults);
-            File cypherDir = new File(importdir,"transactions");
-            if(!cypherDir.isDirectory()) {
-                boolean created = cypherDir.mkdir();
-                if(!created) {
-                    throw new IllegalStateException("Directory could not be created: "+cypherDir);
-                }
-            }
-            csvWriter.exportN2OImportConfig(cypherDir);
+		if (config.equals("none")) {
+			config = null;
+		}
 
-        } catch (IOException | N2OException | InterruptedException | ExecutionException | OWLOntologyCreationException e) {
-            e.printStackTrace();
-            System.exit(1);
-        }
+		N2OImportService importService = new N2OImportService();
+		N2OImportResult importResults = new N2OImportResult();
+		try {
+			importService.prepareConfig(config, importdir);
+			N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(url, importdir, importResults, enableReasoning);
+			File cypherDir = new File(importdir, "transactions");
+			if (!cypherDir.isDirectory()) {
+				boolean created = cypherDir.mkdir();
+				if (!created) {
+					throw new IllegalStateException("Directory could not be created: " + cypherDir);
+				}
+			}
+			csvWriter.exportN2OImportConfig(cypherDir);
 
-    }
+		} catch (IOException | N2OException | InterruptedException | ExecutionException
+				| OWLOntologyCreationException e) {
+			e.printStackTrace();
+			System.exit(1);
+		}
+
+	}
 }

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OOntologyLoader.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OOntologyLoader.java
@@ -15,7 +15,7 @@ import org.semanticweb.owlapi.search.EntitySearcher;
 import java.util.*;
 import java.util.stream.Collectors;
 
-class N2OOntologyLoader {
+public class N2OOntologyLoader {
 
     private final Set<OWLEntity> filterout = new HashSet<>();
     private N2OImportManager manager;
@@ -80,7 +80,7 @@ class N2OOntologyLoader {
 
     }
 
-    private Set<OWLNamedIndividual> getInstances(OWLReasoner r, OWLClassExpression e) {
+    public Set<OWLNamedIndividual> getInstances(OWLReasoner r, OWLClassExpression e) {
         Set<OWLNamedIndividual> instances = new HashSet<>(r.getInstances(e, false).getFlattened());
         instances.removeAll(filterout.stream().filter(OWLEntity::isOWLNamedIndividual).map(OWLEntity::asOWLNamedIndividual).collect(Collectors.toSet()));
         return instances;
@@ -91,7 +91,7 @@ class N2OOntologyLoader {
     }
 
 
-    private Set<OWLClass> getSubClasses(OWLReasoner r, OWLClassExpression e, boolean direct, boolean excludeEquivalentClasses) {
+    public Set<OWLClass> getSubClasses(OWLReasoner r, OWLClassExpression e, boolean direct, boolean excludeEquivalentClasses) {
         Set<OWLClass> subclasses = new HashSet<>(r.getSubClasses(e, direct).getFlattened());
         subclasses.addAll(r.getEquivalentClasses(e).getEntities());
         subclasses.removeAll(filterout.stream().filter(OWLEntity::isOWLClass).map(OWLEntity::asOWLClass).collect(Collectors.toSet()));

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OOntologyLoader.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OOntologyLoader.java
@@ -17,457 +17,609 @@ import java.util.stream.Collectors;
 
 public class N2OOntologyLoader {
 
-    private final Set<OWLEntity> filterout = new HashSet<>();
-    private N2OImportManager manager;
-    private final N2OLog log = N2OLog.getInstance();
-    private RelationTypeCounter relationTypeCounter;
+	private final Set<OWLEntity> filterout = new HashSet<>();
+	private N2OImportManager manager;
+	private final N2OLog log = N2OLog.getInstance();
+	private RelationTypeCounter relationTypeCounter;
+	private Boolean enableReasoning;
 
-    /**
-     * Imports an ontology into neo4j
-     *
-     * @param o         ontology object that contains the axioms to be processed
-     */
-    void importOntology(OWLOntology o, N2OImportResult result) throws N2OException {
-        IRIManager iriManager = new IRIManager();
-        manager = new N2OImportManager(o, iriManager);
-        this.relationTypeCounter = new RelationTypeCounter(N2OConfig.getInstance().getRelationTypeThreshold());
+	/**
+	 * Imports an ontology into neo4j
+	 *
+	 * @param o               ontology object that contains the axioms to be
+	 *                        processed
+	 * @param enableReasoning if true (default value), enables reasoning. Otherwise,
+	 *                        assumes ontology is pre-reasoned and utilizes query
+	 *                        for performance.
+	 */
+	void importOntology(OWLOntology o, N2OImportResult result, Boolean enableReasoning) throws N2OException {
+		IRIManager iriManager = new IRIManager();
+		manager = new N2OImportManager(o, iriManager);
+		this.enableReasoning = enableReasoning;
+		this.relationTypeCounter = new RelationTypeCounter(N2OConfig.getInstance().getRelationTypeThreshold());
 
-        log.log("Preparing reasoner");
-        OWLReasoner r = new ElkReasonerFactory().createReasoner(o);
-        filterout.add(o.getOWLOntologyManager().getOWLDataFactory().getOWLThing());
-        filterout.add(o.getOWLOntologyManager().getOWLDataFactory().getOWLNothing());
-        filterout.addAll(r.getUnsatisfiableClasses().getEntities());
+		filterout.add(o.getOWLOntologyManager().getOWLDataFactory().getOWLThing());
+		filterout.add(o.getOWLOntologyManager().getOWLDataFactory().getOWLNothing());
 
-        log.log("Extracting signature");
-        extractSignature(o, result);
-        log.log("Extracting annotations to literals");
-        indexIndividualAnnotationsToEntities(o);
-        log.log("Extracting subclass relations");
-        addSubclassRelations(o, r);
-        log.log("Extracting class assertions");
-        addClassAssertions(o, r);
-        log.log("Extracting existential relations");
-        addExistentialRelationships(o, r);
-        log.log("Computing dynamic node labels..");
-        addDynamicNodeLabels(r);
+		OWLReasoner r = null;
+		if (enableReasoning) {
+			log.log("Preparing reasoner");
+			r = new ElkReasonerFactory().createReasoner(o);
+			filterout.addAll(r.getUnsatisfiableClasses().getEntities());
+		} else {
+			log.log("Reasoning disabled.");
+		}
 
-    }
+		log.log("Extracting signature");
+		extractSignature(o, result);
+		log.log("Extracting annotations to literals");
+		indexIndividualAnnotationsToEntities(o);
+		log.log("Extracting subclass relations");
+		addSubclassRelations(o, r);
+		log.log("Extracting class assertions");
+		addClassAssertions(o, r);
+		log.log("Extracting existential relations");
+		addExistentialRelationships(o);
+		log.log("Computing dynamic node labels..");
+		addDynamicNodeLabels(o, r);
 
-    private void addDynamicNodeLabels(OWLReasoner r) throws N2OException {
-        Map<String, Set<String>> classExpressionLabelMap = N2OConfig.getInstance().getClassExpressionNeoLabelMap();
-        for (String ces : classExpressionLabelMap.keySet()) {
-            Set<String> labels = classExpressionLabelMap.get(ces);
-            for (String label:labels) {
-                log.info("Adding label " + label + " to " + ces + ".");
-                try {
-                    OWLClassExpression ce = manager.parseExpression(ces);
-                    if (label.isEmpty()) {
-                        if (ce.isClassExpressionLiteral()) {
-                            label = formatAsNeoNodeLabel(ce.asOWLClass());
-                        } else {
-                            log.warning("During adding of dynamic neo labels, an empty label was encountered in conjunction with a complex class expression (" + N2OUtils.render(ce) + "). The label was not added.");
-                        }
-                    }
-                    if (!label.isEmpty()) {
-                        for (OWLClass sc : getSubClasses(r, ce, false, false)) manager.addNodeLabel(sc, label);
-                        for (OWLNamedIndividual sc : getInstances(r, ce)) manager.addNodeLabel(sc, label);
-                    }
-                } catch (Exception e) {
-                    throw new N2OException("FAILED adding label " + label + " to " + ces, e);
-                }
-            }
-        }
+	}
 
-    }
+	private void addDynamicNodeLabels(OWLOntology o, OWLReasoner r) throws N2OException {
+		Map<String, Set<String>> classExpressionLabelMap = N2OConfig.getInstance().getClassExpressionNeoLabelMap();
+		for (String ces : classExpressionLabelMap.keySet()) {
+			Set<String> labels = classExpressionLabelMap.get(ces);
+			for (String label : labels) {
+				log.info("Adding label " + label + " to " + ces + ".");
+				try {
+					OWLClassExpression ce = manager.parseExpression(ces);
+					if (label.isEmpty()) {
+						if (ce.isClassExpressionLiteral()) {
+							label = formatAsNeoNodeLabel(ce.asOWLClass());
+						} else {
+							log.warning(
+									"During adding of dynamic neo labels, an empty label was encountered in conjunction with a complex class expression ("
+											+ N2OUtils.render(ce) + "). The label was not added.");
+						}
+					}
+					if (!label.isEmpty()) {
+						for (OWLClass sc : getSubClasses(o, r, ce, false, false))
+							manager.addNodeLabel(sc, label);
+						for (OWLNamedIndividual sc : getInstances(o, r, ce))
+							manager.addNodeLabel(sc, label);
+					}
+				} catch (Exception e) {
+					throw new N2OException("FAILED adding label " + label + " to " + ces, e);
+				}
+			}
+		}
 
-    public Set<OWLNamedIndividual> getInstances(OWLReasoner r, OWLClassExpression e) {
-        Set<OWLNamedIndividual> instances = new HashSet<>(r.getInstances(e, false).getFlattened());
-        instances.removeAll(filterout.stream().filter(OWLEntity::isOWLNamedIndividual).map(OWLEntity::asOWLNamedIndividual).collect(Collectors.toSet()));
-        return instances;
-    }
-    
-    private Set<OWLClass> getSubClasses(OWLReasoner r, OWLClassExpression e, boolean direct) {
-    	return getSubClasses(r, e, direct, true);
-    }
+	}
 
+	public Set<OWLNamedIndividual> getInstances(OWLOntology o, OWLReasoner r, OWLClassExpression e) {
+		if (this.enableReasoning) {
+			return getInstances(r, e);
+		} else {
+			return queryInstances(o, e);
+		}
+	}
 
-    public Set<OWLClass> getSubClasses(OWLReasoner r, OWLClassExpression e, boolean direct, boolean excludeEquivalentClasses) {
-        Set<OWLClass> subclasses = new HashSet<>(r.getSubClasses(e, direct).getFlattened());
-        subclasses.addAll(r.getEquivalentClasses(e).getEntities());
-        subclasses.removeAll(filterout.stream().filter(OWLEntity::isOWLClass).map(OWLEntity::asOWLClass).collect(Collectors.toSet()));
-        if (excludeEquivalentClasses && e.isClassExpressionLiteral()) {
-            subclasses.remove(e.asOWLClass());
-        }
-        return subclasses;
-    }
+	public Set<OWLNamedIndividual> getInstances(OWLReasoner r, OWLClassExpression e) {
+		Set<OWLNamedIndividual> instances = new HashSet<>(r.getInstances(e, false).getFlattened());
+		instances.removeAll(filterout.stream().filter(OWLEntity::isOWLNamedIndividual)
+				.map(OWLEntity::asOWLNamedIndividual).collect(Collectors.toSet()));
+		return instances;
+	}
 
-    private String formatAsNeoNodeLabel(OWLClass c) {
-        String s = manager.getNode(c).map(N2OEntity::getLabel).orElse(c.getIRI().getShortForm());
-        s = s.replaceAll("[^A-Za-z0-9]", "_");
-        s = StringUtils.capitalize(s.toLowerCase());
-        return s;
-    }
+	public Set<OWLNamedIndividual> queryInstances(OWLOntology o, OWLClassExpression e) {
+		Set<OWLClass> subClasses;
+		if (!e.isAnonymous()) {
+			subClasses = querySubClasses(o, e.asOWLClass(), false, false);
+		} else {
+			subClasses = querySubClassesOfClassExpression(o, e, false, false);
+		}
+		Set<OWLNamedIndividual> indvs = new HashSet<>();
+		for (OWLClass clazz : subClasses) {
+			Collection<OWLIndividual> individuals = EntitySearcher.getIndividuals(clazz, o);
+			for (OWLIndividual indv : individuals) {
+				if (indv instanceof OWLNamedIndividual) {
+					indvs.add((OWLNamedIndividual) indv);
+				}
+			}
+		}
+		return indvs;
+	}
 
-    /**
-     * Iterates through all entities in the ontologies' signature and, for each entity,
-     * 1. Stores them as node objects
-     * 2. Extract annotations directly on the entity and stores them
-     * 3.
-     *
-     * @param o      Ontology from which the signature is extracted
-     * @param result result object to take care of gathering some statistics
-     */
-    private void extractSignature(OWLOntology o, N2OImportResult result) {
-        Set<OWLEntity> entities = new HashSet<>(o.getSignature(Imports.INCLUDED));
-        int i = 0;
-        for (OWLEntity e : entities) {
-            i++;
-            if (i % 1000 == 0) {
-                log.log(i + " out of " + entities.size());
-            }
-            Optional<N2OEntity> one = manager.getNode(e);
-            if (one.isPresent()) {
-                N2OEntity ne = one.get();
-                Map<String, Object> props = ne.getNodeBuiltInMetadataAsMap();
-                props.put(N2OStatic.ATT_QUALIFIED_SAFE_LABEL, manager.prepareQSL(ne));
-                extractIndividualAnnotations(e, props, o);
-                createNode(ne, props);
-                result.countLoaded(e);
-            }
-        }
-        if (!N2OConfig.getInstance().safeLabelMode().equals(LABELLING_MODE.QSL))
-            manager.checkUniqueSafeLabel(N2OConfig.getInstance().safeLabelMode());
-    }
+	private Set<OWLClass> getSubClasses(OWLOntology o, OWLReasoner r, OWLClassExpression e, boolean direct,
+			boolean excludeEquivalentClasses) {
+		if (this.enableReasoning) {
+			return getSubClasses(r, e, direct, excludeEquivalentClasses);
+		} else {
+			if (!e.isAnonymous()) {
+				return querySubClasses(o, e.asOWLClass(), direct, excludeEquivalentClasses);
+			} else {
+				return querySubClassesOfClassExpression(o, e, direct, excludeEquivalentClasses);
+			}
+		}
+	}
 
-    /**
-     * @param e     The entity from which the annotations are extracted
-     * @param props The property map of the entity (neo properties)
-     * @param o the ontology
-     */
-    private void extractIndividualAnnotations(OWLEntity e, Map<String, Object> props, OWLOntology o) {
-        Collection<OWLAnnotationAssertionAxiom> annos = EntitySearcher.getAnnotationAssertionAxioms(e, o);
-        Map<String, Set<Object>> propertyAnnotationValueMap = new HashMap<>();
-        for (OWLAnnotationAssertionAxiom ax : annos) {
-            OWLAnnotation a = ax.getAnnotation();
-            OWLAnnotationValue aval = a.annotationValue();
-            if (!aval.asIRI().isPresent()) {
-                Optional<String> opt_sl_annop = manager.getSLFromAnnotation(a);
-                if (opt_sl_annop.isPresent()) {
-                    String sl_annop = opt_sl_annop.get();
-                    Object value = N2OUtils.extractValueFromOWLAnnotationValue(aval);
-                    relationTypeCounter.increment(sl_annop,value);
-                    if (a.getProperty().equals(N2OStatic.ap_neo4jLabel)) {
-                        manager.addNodeLabel(e, value.toString());
-                    } else {
-                        value = removeAnnotationDelimitersFromAnnotationValue(value);
-                        Set<OWLAnnotation> axiomAnnotations = ax.getAnnotations();
-                        if (N2OConfig.getInstance().isShouldPropertyBeRolledAsJSON(a.getProperty())) {
-                            Map<String, Set<Object>> axAnnos = manager.extractAxiomAnnotationsIntoValueMap(axiomAnnotations,true);
-                            axAnnos.forEach((k,v)->v.forEach(obj->relationTypeCounter.increment(k,obj)));
-                            String valueAnnotated = createAxiomAnnotationJSONString(value, axAnnos);
-                            //log.info(valueAnnotated);
-                            addAnnotationValueToValueMap(propertyAnnotationValueMap, sl_annop, valueAnnotated);
-                        } else {
-                            addAnnotationValueToValueMap(propertyAnnotationValueMap, sl_annop, value);
-                        }
-                    }
-                }
-            }
-        }
-        convertPropertyAnnotationValueMapToEntityPropertyMap(props, propertyAnnotationValueMap);
-    }
+	public Set<OWLClass> getSubClasses(OWLReasoner r, OWLClassExpression e, boolean direct,
+			boolean excludeEquivalentClasses) {
+		Set<OWLClass> subclasses = new HashSet<>(r.getSubClasses(e, direct).getFlattened());
+		subclasses.addAll(r.getEquivalentClasses(e).getEntities());
+		subclasses.removeAll(filterout.stream().filter(OWLEntity::isOWLClass).map(OWLEntity::asOWLClass)
+				.collect(Collectors.toSet()));
+		if (excludeEquivalentClasses && e.isClassExpressionLiteral()) {
+			subclasses.remove(e.asOWLClass());
+		}
+		return subclasses;
+	}
 
-    private void convertPropertyAnnotationValueMapToEntityPropertyMap(Map<String, Object> props, Map<String, Set<Object>> propertyAnnotationValueMap) {
-        propertyAnnotationValueMap.forEach((k, v) -> {
-            if(!v.isEmpty()) {
-                if (v.size() == 1) {
-                    props.put(k, v.iterator().next());
-                } else {
-                    Set<String> s = v.stream().map(Object::toString).collect(Collectors.toSet());
-                    props.put(k, String.join(N2OStatic.ANNOTATION_DELIMITER, s));
-                }
-            }
-        });
-    }
+	public Set<OWLClass> querySubClasses(OWLOntology o, OWLClass e, boolean direct, boolean excludeEquivalentClasses) {
+		return querySubClasses(o, e.asOWLClass(), direct, excludeEquivalentClasses, new HashSet<OWLClass>());
+	}
 
-    private Object removeAnnotationDelimitersFromAnnotationValue(Object value) {
-        if (value.toString().contains(N2OStatic.ANNOTATION_DELIMITER)) {
-            System.err.println("Warning: annotation value " + value + " contains delimiter sequence " + N2OStatic.ANNOTATION_DELIMITER + " which will not be preserved!");
-            value = value.toString().replaceAll(N2OStatic.ANNOTATION_DELIMITER_ESCAPED, "|Content removed during Neo4J Import|");
-        }
-        return value;
-    }
+	private Set<OWLClass> querySubClasses(OWLOntology o, OWLClass e, boolean direct, boolean excludeEquivalentClasses,
+			Set<OWLClass> scannedClasses) {
+		Set<OWLSubClassOfAxiom> subClassAxioms = o.getSubClassAxiomsForSuperClass(e);
+		Set<OWLClass> subClasses = subClassAxioms.stream().filter(scoa -> !scoa.getSubClass().isAnonymous())
+				.map(scoa -> scoa.getSubClass().asOWLClass()).collect(Collectors.toSet());
 
+		subClasses.addAll(queryEquivalentClasses(o, e));
 
+		if (!direct) {
+			subClasses.add(e);
+			Set<OWLClass> indepthSubClasses = new HashSet<>();
+			for (OWLClass subclass : subClasses) {
+				if (!scannedClasses.contains(subclass)) {
+					scannedClasses.add(subclass);
+					indepthSubClasses
+							.addAll(querySubClasses(o, subclass, direct, excludeEquivalentClasses, scannedClasses));
+				}
+			}
+			subClasses.addAll(indepthSubClasses);
+		}
 
-    private String createAxiomAnnotationJSONString(Object value, Map<String, Set<Object>> axAnnos) {
-        JSONObject json = new JSONObject();
-        JSONObject annotations = new JSONObject();
+		if (excludeEquivalentClasses && e.isClassExpressionLiteral()) {
+			subClasses.remove(e.asOWLClass());
+		}
 
-        //{ "value": "def...", "annotations": {"database_cross_reference": [ "FlyBase:FBrf0052913","FlyBase:FBrf0064800" ]}}
+		return subClasses;
+	}
 
-        json.put("value", value);
-        json.put("annotations", annotations);
+	public Set<OWLClass> querySubClassesOfClassExpression(OWLOntology o, OWLClassExpression e, boolean direct,
+			boolean excludeEquivalentClasses) {
+		return querySubClassesOfClassExpression(o, e, direct, excludeEquivalentClasses, new HashSet<OWLClass>());
+	}
 
-        for (String axAnnosRel : axAnnos.keySet()) {
+	private Set<OWLClass> querySubClassesOfClassExpression(OWLOntology o, OWLClassExpression e, boolean direct,
+			boolean excludeEquivalentClasses, Set<OWLClass> scannedClasses) {
+		Set<OWLClass> subClasses = new HashSet<>();
+		for (final OWLSubClassOfAxiom subClasse : o.getAxioms(AxiomType.SUBCLASS_OF)) {
+			if (subClasse.getSuperClass().equals(e)) {
+				if (!subClasse.getSubClass().isAnonymous()) {
+					subClasses.add(subClasse.getSubClass().asOWLClass());
+				}
+			}
+		}
 
-            Set<Object> values = new HashSet<>();
-            for (Object ov : axAnnos.get(axAnnosRel)) {
-                if (ov instanceof String) {
-                    ov = ov.toString().replaceAll(N2OStatic.ANNOTATION_DELIMITER_ESCAPED,
-                            "|Content removed during Neo4J Import|");
-                }
-                values.add(ov);
-            }
-            annotations.put(axAnnosRel,new ArrayList<>(values));
-        }
+		if (!direct) {
+			Set<OWLClass> indepthSubClasses = new HashSet<>();
+			for (OWLClass subclass : subClasses) {
+				if (!scannedClasses.contains(subclass)) {
+					scannedClasses.add(subclass);
+					indepthSubClasses
+							.addAll(querySubClasses(o, subclass, direct, excludeEquivalentClasses, scannedClasses));
+				}
+			}
+			subClasses.addAll(indepthSubClasses);
+		}
 
-        return json.toString();
-    }
+		if (excludeEquivalentClasses && e.isClassExpressionLiteral()) {
+			subClasses.remove(e.asOWLClass());
+		}
 
-    private void addAnnotationValueToValueMap(Map<String, Set<Object>> propertyAnnotationValueMap, String sl_annop, Object value) {
-        if (!propertyAnnotationValueMap.containsKey(sl_annop))
-            propertyAnnotationValueMap.put(sl_annop, new HashSet<>());
-        propertyAnnotationValueMap.get(sl_annop).add(value);
-    }
+		return subClasses;
+	}
 
+	private Set<OWLClass> queryEquivalentClasses(OWLOntology o, OWLClassExpression e) {
+		Set<OWLEquivalentClassesAxiom> equivalentClassesAxioms = o.getEquivalentClassesAxioms(e.asOWLClass());
+		Set<OWLClass> eqClasses = new HashSet<>();
+		for (OWLEquivalentClassesAxiom eca : equivalentClassesAxioms) {
+			eqClasses.addAll(eca.getNamedClasses());
+		}
 
-    private void createNode(N2OEntity e, Map<String, Object> props) {
-        manager.updateNode(e.getEntity(), props);
-    }
+		return eqClasses;
+	}
 
-    /**
-     * @param o Ontology whose signature is indexed
-     */
-    private void indexIndividualAnnotationsToEntities(OWLOntology o) {
-        Set<OWLEntity> entities = new HashSet<>(o.getSignature(Imports.INCLUDED));
-        for (OWLEntity e : entities) {
-            //Map<String, Object> props = new HashMap<>();
-            Collection<OWLAnnotationAssertionAxiom> annos = EntitySearcher.getAnnotationAssertionAxioms(e, o);
-            for (OWLAnnotationAssertionAxiom a : annos) {
-                OWLAnnotationValue aval = a.annotationValue();
-                if (aval.asIRI().isPresent()) {
-                    IRI iri = aval.asIRI().or(IRI.create("WRONGANNOTATIONPROPERTY"));
-                    Optional<N2OEntity> n2OEntity = manager.getNode(a.getProperty());
-                    n2OEntity.ifPresent(oEntity -> indexRelation(e, manager.typedEntity(iri, o), oEntity, a.getAnnotations()));
-                }
-            }
-        }
-    }
+	private String formatAsNeoNodeLabel(OWLClass c) {
+		String s = manager.getNode(c).map(N2OEntity::getLabel).orElse(c.getIRI().getShortForm());
+		s = s.replaceAll("[^A-Za-z0-9]", "_");
+		s = StringUtils.capitalize(s.toLowerCase());
+		return s;
+	}
 
-    private void indexRelation(OWLEntity from, OWLEntity to, N2OEntity rel, Set<OWLAnnotation> annos) {
-        if (filterout.contains(from)) {
-            return;
-        } else if (filterout.contains(to)) {
-            return;
-        }
-        Optional<N2OEntity> from_n = manager.getNode(from);
-        if (!from_n.isPresent()) {
-            return;
-        }
-        Optional<N2OEntity> to_n = manager.getNode(to);
-        if (!to_n.isPresent()) {
-            return;
-        }
+	/**
+	 * Iterates through all entities in the ontologies' signature and, for each
+	 * entity, 1. Stores them as node objects 2. Extract annotations directly on the
+	 * entity and stores them 3.
+	 *
+	 * @param o      Ontology from which the signature is extracted
+	 * @param result result object to take care of gathering some statistics
+	 */
+	private void extractSignature(OWLOntology o, N2OImportResult result) {
+		Set<OWLEntity> entities = new HashSet<>(o.getSignature(Imports.INCLUDED));
+		int i = 0;
+		for (OWLEntity e : entities) {
+			i++;
+			if (i % 1000 == 0) {
+				log.log(i + " out of " + entities.size());
+			}
+			Optional<N2OEntity> one = manager.getNode(e);
+			if (one.isPresent()) {
+				N2OEntity ne = one.get();
+				Map<String, Object> props = ne.getNodeBuiltInMetadataAsMap();
+				props.put(N2OStatic.ATT_QUALIFIED_SAFE_LABEL, manager.prepareQSL(ne));
+				extractIndividualAnnotations(e, props, o);
+				createNode(ne, props);
+				result.countLoaded(e);
+			}
+		}
+		if (!N2OConfig.getInstance().safeLabelMode().equals(LABELLING_MODE.QSL))
+			manager.checkUniqueSafeLabel(N2OConfig.getInstance().safeLabelMode());
+	}
 
-        String roletype = manager.prepareQSL(rel);
+	/**
+	 * @param e     The entity from which the annotations are extracted
+	 * @param props The property map of the entity (neo properties)
+	 * @param o     the ontology
+	 */
+	private void extractIndividualAnnotations(OWLEntity e, Map<String, Object> props, OWLOntology o) {
+		Collection<OWLAnnotationAssertionAxiom> annos = EntitySearcher.getAnnotationAssertionAxioms(e, o);
+		Map<String, Set<Object>> propertyAnnotationValueMap = new HashMap<>();
+		for (OWLAnnotationAssertionAxiom ax : annos) {
+			OWLAnnotation a = ax.getAnnotation();
+			OWLAnnotationValue aval = a.annotationValue();
+			if (!aval.asIRI().isPresent()) {
+				Optional<String> opt_sl_annop = manager.getSLFromAnnotation(a);
+				if (opt_sl_annop.isPresent()) {
+					String sl_annop = opt_sl_annop.get();
+					Object value = N2OUtils.extractValueFromOWLAnnotationValue(aval);
+					relationTypeCounter.increment(sl_annop, value);
+					if (a.getProperty().equals(N2OStatic.ap_neo4jLabel)) {
+						manager.addNodeLabel(e, value.toString());
+					} else {
+						value = removeAnnotationDelimitersFromAnnotationValue(value);
+						Set<OWLAnnotation> axiomAnnotations = ax.getAnnotations();
+						if (N2OConfig.getInstance().isShouldPropertyBeRolledAsJSON(a.getProperty())) {
+							Map<String, Set<Object>> axAnnos = manager
+									.extractAxiomAnnotationsIntoValueMap(axiomAnnotations, true);
+							axAnnos.forEach((k, v) -> v.forEach(obj -> relationTypeCounter.increment(k, obj)));
+							String valueAnnotated = createAxiomAnnotationJSONString(value, axAnnos);
+							// log.info(valueAnnotated);
+							addAnnotationValueToValueMap(propertyAnnotationValueMap, sl_annop, valueAnnotated);
+						} else {
+							addAnnotationValueToValueMap(propertyAnnotationValueMap, sl_annop, value);
+						}
+					}
+				}
+			}
+		}
+		convertPropertyAnnotationValueMapToEntityPropertyMap(props, propertyAnnotationValueMap);
+	}
 
-        Map<String, Set<Object>> props = manager.extractAxiomAnnotationsIntoValueMap(annos,true);
-        props.forEach((k,v)->v.forEach(obj->relationTypeCounter.increment(k,obj)));
-        manager.addRelation(new N2ORelationship(from_n.get(), to_n.get(), roletype, props));
-    }
+	private void convertPropertyAnnotationValueMapToEntityPropertyMap(Map<String, Object> props,
+			Map<String, Set<Object>> propertyAnnotationValueMap) {
+		propertyAnnotationValueMap.forEach((k, v) -> {
+			if (!v.isEmpty()) {
+				if (v.size() == 1) {
+					props.put(k, v.iterator().next());
+				} else {
+					Set<String> s = v.stream().map(Object::toString).collect(Collectors.toSet());
+					props.put(k, String.join(N2OStatic.ANNOTATION_DELIMITER, s));
+				}
+			}
+		});
+	}
 
-    private void addSubclassRelations(OWLOntology o, OWLReasoner r) {
-        Set<OWLClass> entities = new HashSet<>(o.getClassesInSignature(Imports.INCLUDED));
-        for (OWLClass e : entities) {
-            if (filterout.contains(e)) {
-                continue;
-            }
-            for (OWLClass sub : getSubClasses(r, e, true)) {
+	private Object removeAnnotationDelimitersFromAnnotationValue(Object value) {
+		if (value.toString().contains(N2OStatic.ANNOTATION_DELIMITER)) {
+			System.err.println("Warning: annotation value " + value + " contains delimiter sequence "
+					+ N2OStatic.ANNOTATION_DELIMITER + " which will not be preserved!");
+			value = value.toString().replaceAll(N2OStatic.ANNOTATION_DELIMITER_ESCAPED,
+					"|Content removed during Neo4J Import|");
+		}
+		return value;
+	}
 
-                //System.out.println(e+" sub: "+sub);
-                Map<String, Object> props = new HashMap<>();
-                props.put("id", N2OStatic.RELTYPE_SUBCLASSOF);
-                Optional<N2OEntity> n2OEntitySub = manager.getNode(sub);
-                Optional<N2OEntity> n2OEntity = manager.getNode(e);
-                if (n2OEntitySub.isPresent() && n2OEntity.isPresent()) {
-                    updateRelationship(n2OEntitySub.get(), n2OEntity.get(), props);
-                }
+	private String createAxiomAnnotationJSONString(Object value, Map<String, Set<Object>> axAnnos) {
+		JSONObject json = new JSONObject();
+		JSONObject annotations = new JSONObject();
 
-            }
-        }
-    }
+		// { "value": "def...", "annotations": {"database_cross_reference": [
+		// "FlyBase:FBrf0052913","FlyBase:FBrf0064800" ]}}
 
-    private void addClassAssertions(OWLOntology o, OWLReasoner r) {
-        Set<OWLNamedIndividual> entities = new HashSet<>(o.getIndividualsInSignature(Imports.INCLUDED));
-        for (OWLNamedIndividual e : entities) {
-            if (filterout.contains(e)) {
-                continue;
-            }
-            for (OWLClass type : r.getTypes(e, true).getFlattened()) {
-                if (filterout.contains(type)) {
-                    continue;
-                }
-                Map<String, Object> props = new HashMap<>();
-                props.put("id", N2OStatic.RELTYPE_INSTANCEOF);
+		json.put("value", value);
+		json.put("annotations", annotations);
 
-                Optional<N2OEntity> n2OEntityType = manager.getNode(type);
-                Optional<N2OEntity> n2OEntity = manager.getNode(e);
-                if (n2OEntityType.isPresent() && n2OEntity.isPresent()) {
-                    updateRelationship(n2OEntity.get(), n2OEntityType.get(), props);
-                }
-            }
-        }
-    }
+		for (String axAnnosRel : axAnnos.keySet()) {
 
+			Set<Object> values = new HashSet<>();
+			for (Object ov : axAnnos.get(axAnnosRel)) {
+				if (ov instanceof String) {
+					ov = ov.toString().replaceAll(N2OStatic.ANNOTATION_DELIMITER_ESCAPED,
+							"|Content removed during Neo4J Import|");
+				}
+				values.add(ov);
+			}
+			annotations.put(axAnnosRel, new ArrayList<>(values));
+		}
 
-    private void addExistentialRelationships(OWLOntology o, OWLReasoner r) {
-        processLogicallyConnectedEntities(r, o);
-        updateMetadataOfAllIndexedRelationships();
-    }
+		return json.toString();
+	}
 
-    private void updateMetadataOfAllIndexedRelationships() {
-        for (N2ORelationship relationship : manager.getRelationships()) {
-            N2OEntity e = relationship.getStart();
-            if (filterout.contains(e.getEntity())) {
-                continue;
-            }
+	private void addAnnotationValueToValueMap(Map<String, Set<Object>> propertyAnnotationValueMap, String sl_annop,
+			Object value) {
+		if (!propertyAnnotationValueMap.containsKey(sl_annop))
+			propertyAnnotationValueMap.put(sl_annop, new HashSet<>());
+		propertyAnnotationValueMap.get(sl_annop).add(value);
+	}
 
-            N2OEntity ec = relationship.getEnd();
+	private void createNode(N2OEntity e, Map<String, Object> props) {
+		manager.updateNode(e.getEntity(), props);
+	}
 
-            if (filterout.contains(ec.getEntity())) {
-                continue;
-            }
+	/**
+	 * @param o Ontology whose signature is indexed
+	 */
+	private void indexIndividualAnnotationsToEntities(OWLOntology o) {
+		Set<OWLEntity> entities = new HashSet<>(o.getSignature(Imports.INCLUDED));
+		for (OWLEntity e : entities) {
+			// Map<String, Object> props = new HashMap<>();
+			Collection<OWLAnnotationAssertionAxiom> annos = EntitySearcher.getAnnotationAssertionAxioms(e, o);
+			for (OWLAnnotationAssertionAxiom a : annos) {
+				OWLAnnotationValue aval = a.annotationValue();
+				if (aval.asIRI().isPresent()) {
+					IRI iri = aval.asIRI().or(IRI.create("WRONGANNOTATIONPROPERTY"));
+					Optional<N2OEntity> n2OEntity = manager.getNode(a.getProperty());
+					n2OEntity.ifPresent(
+							oEntity -> indexRelation(e, manager.typedEntity(iri, o), oEntity, a.getAnnotations()));
+				}
+			}
+		}
+	}
 
-            Map<String, Object> props = prepareRelationshipProperties(relationship);
-            updateRelationship(e, ec, props);
-        }
-    }
+	private void indexRelation(OWLEntity from, OWLEntity to, N2OEntity rel, Set<OWLAnnotation> annos) {
+		if (filterout.contains(from)) {
+			return;
+		} else if (filterout.contains(to)) {
+			return;
+		}
+		Optional<N2OEntity> from_n = manager.getNode(from);
+		if (!from_n.isPresent()) {
+			return;
+		}
+		Optional<N2OEntity> to_n = manager.getNode(to);
+		if (!to_n.isPresent()) {
+			return;
+		}
 
+		String roletype = manager.prepareQSL(rel);
 
+		Map<String, Set<Object>> props = manager.extractAxiomAnnotationsIntoValueMap(annos, true);
+		props.forEach((k, v) -> v.forEach(obj -> relationTypeCounter.increment(k, obj)));
+		manager.addRelation(new N2ORelationship(from_n.get(), to_n.get(), roletype, props));
+	}
 
+	private void addSubclassRelations(OWLOntology o, OWLReasoner r) {
+		Set<OWLClass> entities = new HashSet<>(o.getClassesInSignature(Imports.INCLUDED));
+		for (OWLClass e : entities) {
+			if (filterout.contains(e)) {
+				continue;
+			}
+			for (OWLClass sub : getSubClasses(o, r, e, true, true)) {
 
+				// System.out.println(e+" sub: "+sub);
+				Map<String, Object> props = new HashMap<>();
+				props.put("id", N2OStatic.RELTYPE_SUBCLASSOF);
+				Optional<N2OEntity> n2OEntitySub = manager.getNode(sub);
+				Optional<N2OEntity> n2OEntity = manager.getNode(e);
+				if (n2OEntitySub.isPresent() && n2OEntity.isPresent()) {
+					updateRelationship(n2OEntitySub.get(), n2OEntity.get(), props);
+				}
 
+			}
+		}
+	}
 
-    /**
-     * @param relationship Relationship object whose properties are being processed
-     * @return A map of all the properties, including the updated built-in ones.
-     */
-    private Map<String, Object> prepareRelationshipProperties(N2ORelationship relationship) {
-        String rel = relationship.getRelationId();
-        Optional<N2OEntity> relEntity = manager.fromSL(rel);
-        Map<String, Object> props = new HashMap<>();
-        Map<String, Set<Object>> props_rel = relationship.getProps();
-        props_rel.remove(N2OStatic.ATT_IRI);
-        props_rel.remove(N2OStatic.ATT_LABEL);
-        props_rel.remove(N2OStatic.ATT_NODE_TYPE);
-        props_rel.remove(N2OStatic.ATT_SHORT_FORM);
-        props.put("id", rel);
-        convertPropertyAnnotationValueMapToEntityPropertyMap(props, props_rel);
-        if (relEntity.isPresent()) {
-            props.put(N2OStatic.ATT_IRI, relEntity.get().getIri());
-            props.put(N2OStatic.ATT_NODE_TYPE, relEntity.get().getEntityType());
-            props.put(N2OStatic.ATT_LABEL, relEntity.get().getLabel());
-            props.put(N2OStatic.ATT_SHORT_FORM, relEntity.get().getShort_form());
-        }
-        return props;
-    }
+	private void addClassAssertions(OWLOntology o, OWLReasoner r) {
+		Set<OWLNamedIndividual> entities = new HashSet<>(o.getIndividualsInSignature(Imports.INCLUDED));
+		for (OWLNamedIndividual e : entities) {
+			if (filterout.contains(e)) {
+				continue;
+			}
+			for (OWLClass type : getTypes(o, r, e)) {
+				if (filterout.contains(type)) {
+					continue;
+				}
+				Map<String, Object> props = new HashMap<>();
+				props.put("id", N2OStatic.RELTYPE_INSTANCEOF);
 
-    private void processLogicallyConnectedEntities(OWLReasoner r, OWLOntology o) {
-        log.info("processLogicallyConnectedEntities currently does not use the reasoner to infer additional existential restrictions "+r.getReasonerName());
+				Optional<N2OEntity> n2OEntityType = manager.getNode(type);
+				Optional<N2OEntity> n2OEntity = manager.getNode(e);
+				if (n2OEntityType.isPresent() && n2OEntity.isPresent()) {
+					updateRelationship(n2OEntity.get(), n2OEntityType.get(), props);
+				}
+			}
+		}
+	}
 
-        for (OWLAxiom ax : o.getAxioms(Imports.INCLUDED)) {
-            if (ax instanceof OWLSubClassOfAxiom) {
-                // CLASS-CLASS: Simple existential "class" restrictions on classes
-                // CLASS-INDIVIDUAL: Simple existential "individual" restrictions on classes
-                OWLSubClassOfAxiom sax = (OWLSubClassOfAxiom) ax;
-                OWLClassExpression s_super = sax.getSuperClass();
-                OWLClassExpression s_sub = sax.getSubClass();
-                if (s_sub.isClassExpressionLiteral()) {
-                    if (s_super instanceof OWLObjectSomeValuesFrom) {
-                        processExistentialRestriction((OWLObjectSomeValuesFrom) s_super, s_sub.asOWLClass(), ax.getAnnotations());
-                    } else if (s_super instanceof OWLObjectHasValue) {
-                        processExistentialRestriction((OWLObjectSomeValuesFrom) ((OWLObjectHasValue) s_super).asSomeValuesFrom(), s_sub.asOWLClass(), ax.getAnnotations());
-                    }
-                }
-            } else if (ax instanceof OWLEquivalentClassesAxiom) {
-                // CLASS-CLASS: Simple existential "class" restrictions on classes
-                // CLASS-INDIVIDUAL: Simple existential "individual" restrictions on classes
-                OWLEquivalentClassesAxiom eqax = (OWLEquivalentClassesAxiom) ax;
-                Set<OWLClass> names = new HashSet<>();
-                eqax.getClassExpressions().stream().filter(OWLClassExpression::isClassExpressionLiteral).forEach(e -> names.add(e.asOWLClass()));
-                for (OWLClass c : names) {
-                    for (OWLClassExpression e : eqax.getClassExpressionsAsList()) {
-                        if (e instanceof OWLObjectSomeValuesFrom) {
-                            processExistentialRestriction((OWLObjectSomeValuesFrom) e, c, ax.getAnnotations());
-                        }
-                    }
-                }
-            } else if (ax instanceof OWLClassAssertionAxiom) {
-                // INDIVIDUAL-CLASS: Simple existential "individual" restrictions on individuals
-                OWLClassAssertionAxiom eqax = (OWLClassAssertionAxiom) ax;
-                OWLIndividual i = eqax.getIndividual();
-                if (i.isNamed()) {
-                    OWLClassExpression type = eqax.getClassExpression();
-                    if (type instanceof OWLObjectSomeValuesFrom) {
-                        processExistentialRestriction((OWLObjectSomeValuesFrom) type, i.asOWLNamedIndividual(), ax.getAnnotations());
-                    } else if (type instanceof OWLObjectHasValue) {
-                        processExistentialRestriction((OWLObjectSomeValuesFrom) ((OWLObjectHasValue) type).asSomeValuesFrom(), i.asOWLNamedIndividual(), ax.getAnnotations());
-                    }
-                }
-            } else if (ax instanceof OWLObjectPropertyAssertionAxiom) {
-                // INDIVIDUAL-INDIVIDUAL Object Property Assertion
-                OWLObjectPropertyAssertionAxiom eqax = (OWLObjectPropertyAssertionAxiom) ax;
-                OWLIndividual from = eqax.getSubject();
-                if (from.isNamed()) {
-                    OWLIndividual to = eqax.getObject();
-                    if (to.isNamed()) {
-                        if (!eqax.getProperty().isAnonymous()) {
-                            Optional<N2OEntity> e = manager.getNode(eqax.getProperty().asOWLObjectProperty());
-                            e.ifPresent(n2OEntity -> indexRelation(from.asOWLNamedIndividual(), to.asOWLNamedIndividual(), n2OEntity, ax.getAnnotations()));
-                        }
-                    }
-                }
-            }
-        }
-    }
+	private Set<OWLClass> getTypes(OWLOntology o, OWLReasoner r, OWLNamedIndividual e) {
+		if (this.enableReasoning) {
+			return r.getTypes(e, true).getFlattened();
+		} else {
+			return queryTypes(o, e, true);
+		}
+	}
 
-    private void processExistentialRestriction(OWLObjectSomeValuesFrom svf, OWLEntity s_sub, Set<OWLAnnotation> annos) {
-        if (!svf.getProperty().isAnonymous()) {
-            OWLObjectProperty op = svf.getProperty().asOWLObjectProperty();
-            OWLClassExpression filler = svf.getFiller();
-            if (filler.isClassExpressionLiteral() && !filler.isAnonymous()) {
-                // ENTITY-CLASS: A SubClassOf R some B, i:R some B
-                OWLClass c = svf.getFiller().asOWLClass();
-                Optional<N2OEntity> e = manager.getNode(op);
-                e.ifPresent(n2OEntity -> indexRelation(s_sub, c, n2OEntity, annos));
-            } else {
-                // ENTITY-INDIVIDUAL: A SubClassOf R some {i}, i: R some {j}
-                if (filler instanceof OWLObjectOneOf) {
-                    OWLObjectOneOf ce = (OWLObjectOneOf) filler;
-                    if (ce.getIndividuals().size() == 1) { // If there is more than one, we cannot assume a relationship.
-                        for (OWLIndividual i : ce.getIndividuals()) {
-                            if (i.isNamed()) {
-                                Optional<N2OEntity> e = manager.getNode(op);
-                                e.ifPresent(n2OEntity -> indexRelation(s_sub, i.asOWLNamedIndividual(), n2OEntity, annos));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+	public Set<OWLClass> queryTypes(OWLOntology o, OWLNamedIndividual e, boolean direct) {
+		Collection<OWLClassExpression> types = EntitySearcher.getTypes(e, o);
+		return types.stream().filter(type -> !type.isAnonymous()).map(type -> type.asOWLClass())
+				.collect(Collectors.toSet());
+	}
 
-    private void updateRelationship(N2OEntity start_neo, N2OEntity end_neo, Map<String, Object> rel) {
-        manager.updateRelation(start_neo, end_neo, rel);
-    }
+	private void addExistentialRelationships(OWLOntology o) {
+		processLogicallyConnectedEntities(o);
+		updateMetadataOfAllIndexedRelationships();
+	}
 
+	private void updateMetadataOfAllIndexedRelationships() {
+		for (N2ORelationship relationship : manager.getRelationships()) {
+			N2OEntity e = relationship.getStart();
+			if (filterout.contains(e.getEntity())) {
+				continue;
+			}
 
-    public N2OImportManager getImportManager() {
-        return this.manager;
-    }
+			N2OEntity ec = relationship.getEnd();
 
-    public RelationTypeCounter getRelationTypeCounter() {
-        return this.relationTypeCounter;
-    }
+			if (filterout.contains(ec.getEntity())) {
+				continue;
+			}
+
+			Map<String, Object> props = prepareRelationshipProperties(relationship);
+			updateRelationship(e, ec, props);
+		}
+	}
+
+	/**
+	 * @param relationship Relationship object whose properties are being processed
+	 * @return A map of all the properties, including the updated built-in ones.
+	 */
+	private Map<String, Object> prepareRelationshipProperties(N2ORelationship relationship) {
+		String rel = relationship.getRelationId();
+		Optional<N2OEntity> relEntity = manager.fromSL(rel);
+		Map<String, Object> props = new HashMap<>();
+		Map<String, Set<Object>> props_rel = relationship.getProps();
+		props_rel.remove(N2OStatic.ATT_IRI);
+		props_rel.remove(N2OStatic.ATT_LABEL);
+		props_rel.remove(N2OStatic.ATT_NODE_TYPE);
+		props_rel.remove(N2OStatic.ATT_SHORT_FORM);
+		props.put("id", rel);
+		convertPropertyAnnotationValueMapToEntityPropertyMap(props, props_rel);
+		if (relEntity.isPresent()) {
+			props.put(N2OStatic.ATT_IRI, relEntity.get().getIri());
+			props.put(N2OStatic.ATT_NODE_TYPE, relEntity.get().getEntityType());
+			props.put(N2OStatic.ATT_LABEL, relEntity.get().getLabel());
+			props.put(N2OStatic.ATT_SHORT_FORM, relEntity.get().getShort_form());
+		}
+		return props;
+	}
+
+	private void processLogicallyConnectedEntities(OWLOntology o) {
+		log.info(
+				"processLogicallyConnectedEntities currently does not use the reasoner to infer additional existential restrictions ");
+
+		for (OWLAxiom ax : o.getAxioms(Imports.INCLUDED)) {
+			if (ax instanceof OWLSubClassOfAxiom) {
+				// CLASS-CLASS: Simple existential "class" restrictions on classes
+				// CLASS-INDIVIDUAL: Simple existential "individual" restrictions on classes
+				OWLSubClassOfAxiom sax = (OWLSubClassOfAxiom) ax;
+				OWLClassExpression s_super = sax.getSuperClass();
+				OWLClassExpression s_sub = sax.getSubClass();
+				if (s_sub.isClassExpressionLiteral()) {
+					if (s_super instanceof OWLObjectSomeValuesFrom) {
+						processExistentialRestriction((OWLObjectSomeValuesFrom) s_super, s_sub.asOWLClass(),
+								ax.getAnnotations());
+					} else if (s_super instanceof OWLObjectHasValue) {
+						processExistentialRestriction(
+								(OWLObjectSomeValuesFrom) ((OWLObjectHasValue) s_super).asSomeValuesFrom(),
+								s_sub.asOWLClass(), ax.getAnnotations());
+					}
+				}
+			} else if (ax instanceof OWLEquivalentClassesAxiom) {
+				// CLASS-CLASS: Simple existential "class" restrictions on classes
+				// CLASS-INDIVIDUAL: Simple existential "individual" restrictions on classes
+				OWLEquivalentClassesAxiom eqax = (OWLEquivalentClassesAxiom) ax;
+				Set<OWLClass> names = new HashSet<>();
+				eqax.getClassExpressions().stream().filter(OWLClassExpression::isClassExpressionLiteral)
+						.forEach(e -> names.add(e.asOWLClass()));
+				for (OWLClass c : names) {
+					for (OWLClassExpression e : eqax.getClassExpressionsAsList()) {
+						if (e instanceof OWLObjectSomeValuesFrom) {
+							processExistentialRestriction((OWLObjectSomeValuesFrom) e, c, ax.getAnnotations());
+						}
+					}
+				}
+			} else if (ax instanceof OWLClassAssertionAxiom) {
+				// INDIVIDUAL-CLASS: Simple existential "individual" restrictions on individuals
+				OWLClassAssertionAxiom eqax = (OWLClassAssertionAxiom) ax;
+				OWLIndividual i = eqax.getIndividual();
+				if (i.isNamed()) {
+					OWLClassExpression type = eqax.getClassExpression();
+					if (type instanceof OWLObjectSomeValuesFrom) {
+						processExistentialRestriction((OWLObjectSomeValuesFrom) type, i.asOWLNamedIndividual(),
+								ax.getAnnotations());
+					} else if (type instanceof OWLObjectHasValue) {
+						processExistentialRestriction(
+								(OWLObjectSomeValuesFrom) ((OWLObjectHasValue) type).asSomeValuesFrom(),
+								i.asOWLNamedIndividual(), ax.getAnnotations());
+					}
+				}
+			} else if (ax instanceof OWLObjectPropertyAssertionAxiom) {
+				// INDIVIDUAL-INDIVIDUAL Object Property Assertion
+				OWLObjectPropertyAssertionAxiom eqax = (OWLObjectPropertyAssertionAxiom) ax;
+				OWLIndividual from = eqax.getSubject();
+				if (from.isNamed()) {
+					OWLIndividual to = eqax.getObject();
+					if (to.isNamed()) {
+						if (!eqax.getProperty().isAnonymous()) {
+							Optional<N2OEntity> e = manager.getNode(eqax.getProperty().asOWLObjectProperty());
+							e.ifPresent(n2OEntity -> indexRelation(from.asOWLNamedIndividual(),
+									to.asOWLNamedIndividual(), n2OEntity, ax.getAnnotations()));
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private void processExistentialRestriction(OWLObjectSomeValuesFrom svf, OWLEntity s_sub, Set<OWLAnnotation> annos) {
+		if (!svf.getProperty().isAnonymous()) {
+			OWLObjectProperty op = svf.getProperty().asOWLObjectProperty();
+			OWLClassExpression filler = svf.getFiller();
+			if (filler.isClassExpressionLiteral() && !filler.isAnonymous()) {
+				// ENTITY-CLASS: A SubClassOf R some B, i:R some B
+				OWLClass c = svf.getFiller().asOWLClass();
+				Optional<N2OEntity> e = manager.getNode(op);
+				e.ifPresent(n2OEntity -> indexRelation(s_sub, c, n2OEntity, annos));
+			} else {
+				// ENTITY-INDIVIDUAL: A SubClassOf R some {i}, i: R some {j}
+				if (filler instanceof OWLObjectOneOf) {
+					OWLObjectOneOf ce = (OWLObjectOneOf) filler;
+					if (ce.getIndividuals().size() == 1) { // If there is more than one, we cannot assume a
+															// relationship.
+						for (OWLIndividual i : ce.getIndividuals()) {
+							if (i.isNamed()) {
+								Optional<N2OEntity> e = manager.getNode(op);
+								e.ifPresent(
+										n2OEntity -> indexRelation(s_sub, i.asOWLNamedIndividual(), n2OEntity, annos));
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private void updateRelationship(N2OEntity start_neo, N2OEntity end_neo, Map<String, Object> rel) {
+		manager.updateRelation(start_neo, end_neo, rel);
+	}
+
+	public N2OImportManager getImportManager() {
+		return this.manager;
+	}
+
+	public RelationTypeCounter getRelationTypeCounter() {
+		return this.relationTypeCounter;
+	}
 }

--- a/src/test/java/ebi/spot/neo4j2owl/N2ONoReasoningTest.java
+++ b/src/test/java/ebi/spot/neo4j2owl/N2ONoReasoningTest.java
@@ -1,12 +1,13 @@
 package ebi.spot.neo4j2owl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -16,6 +17,7 @@ import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassExpression;
+import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -24,6 +26,7 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
 
 import ebi.spot.neo4j2owl.importer.IRIManager;
 import ebi.spot.neo4j2owl.importer.N2OImportManager;
+import ebi.spot.neo4j2owl.importer.N2OImportResult;
 import ebi.spot.neo4j2owl.importer.N2OOntologyLoader;
 
 /**
@@ -34,10 +37,12 @@ import ebi.spot.neo4j2owl.importer.N2OOntologyLoader;
  */
 class N2ONoReasoningTest {
 
-	private static final File TEST_ONTOLOGY = new File("./src/test/resources/bigtest_reasoned.owl");
+	private static final File TEST_ONTOLOGY = new File("./src/test/resources/bigtest_reasoned_with_tags.owl");
 	private static OWLOntology o;
 	private static N2OOntologyLoader ontologyImporter;
 	private static OWLReasoner r;
+	private static final String CONFIG = "file://bigtest_config.yaml"; 
+	private static File test_output = new File("./src/test/resources/test_output");
 
 	@BeforeAll
 	public static void setup() {
@@ -119,9 +124,34 @@ class N2ONoReasoningTest {
 			}
 		}
 	}
+	
+	@Test
+	void testAddingDynamicAnnotations() throws OWLOntologyCreationException, N2OException, IOException {
+		String annotationIRI = "http://n2o.neo/property/nodeLabel";
+		
+		N2OConfig.getInstance().prepareConfig(CONFIG, test_output);
+		
+		N2OOntologyLoader reasonedLoader = new N2OOntologyLoader();
+		reasonedLoader.importOntology(o, new N2OImportResult(), true, null);
+		
+		N2OOntologyLoader prereasonedLoader = new N2OOntologyLoader();
+		prereasonedLoader.importOntology(o, new N2OImportResult(), false, annotationIRI);
+		
+		Map<OWLEntity, Set<String>> reasonedLabels = reasonedLoader.getImportManager().getNodeLabels();
+		Map<OWLEntity, Set<String>> queriedLabels = prereasonedLoader.getImportManager().getNodeLabels();
+
+		assertTrue(reasonedLabels.keySet().size() > 0);
+		assertEquals(reasonedLabels.keySet().size(), queriedLabels.keySet().size());
+		for (OWLEntity entity : reasonedLabels.keySet()) {
+			System.out.println(entity + "   " + reasonedLabels.get(entity));
+			assertTrue(queriedLabels.containsKey(entity));
+			assertEquals(reasonedLabels.get(entity), queriedLabels.get(entity));
+		}
+		
+	}
 
 	@Test
-	void testGetSubClassesOfExpression1() throws OWLOntologyCreationException {
+	void testGetSubClassesOfExpression() throws OWLOntologyCreationException {
 		IRIManager iriManager = new IRIManager();
 		N2OImportManager manager = new N2OImportManager(o, iriManager);
 		List<String> expressions = new ArrayList<>();
@@ -133,7 +163,8 @@ class N2ONoReasoningTest {
 		expressions.add("RO:0015002 some CL:0000359");
 		expressions.add("RO:0000053 some PATO:0070019");
 		expressions.add("RO:0002100 some UBERON:0002771");
-		// following crashes because, naturally, query cannot handle property chains
+		// following crashes because, query cannot handle sub-property based class expressions
+		// 'in taxonomy' some NCBITaxon:10090  vs 'only in taxonomy' some NCBITaxon:10090
 //		expressions.add("RO:0002162 some NCBITaxon:10090");
 
 		for (String expression : expressions) {

--- a/src/test/java/ebi/spot/neo4j2owl/N2ONoReasoningTest.java
+++ b/src/test/java/ebi/spot/neo4j2owl/N2ONoReasoningTest.java
@@ -1,0 +1,201 @@
+package ebi.spot.neo4j2owl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.semanticweb.elk.owlapi.ElkReasonerFactory;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLClassExpression;
+import org.semanticweb.owlapi.model.OWLEquivalentClassesAxiom;
+import org.semanticweb.owlapi.model.OWLIndividual;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+import org.semanticweb.owlapi.model.parameters.Imports;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.search.EntitySearcher;
+
+import ebi.spot.neo4j2owl.importer.N2OOntologyLoader;
+
+/**
+ * Test that query based functions provides the same results with the reasoning
+ * based functions.
+ * 
+ * @author huseyin
+ */
+class N2ONoReasoningTest {
+
+	private static final File TEST_ONTOLOGY = new File("./src/test/resources/bigtest_reasoned.owl");
+	private static OWLOntology o;
+	private static N2OOntologyLoader ontologyImporter;
+	private static OWLReasoner r;
+
+	@BeforeAll
+	public static void setup() {
+		try {
+			o = OWLManager.createOWLOntologyManager()
+					.loadOntologyFromOntologyDocument(IRI.create(TEST_ONTOLOGY.toURI()));
+			ontologyImporter = new N2OOntologyLoader();
+
+			r = new ElkReasonerFactory().createReasoner(o);
+		} catch (OWLOntologyCreationException e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Test
+	void testGetDirectSubClasses() throws OWLOntologyCreationException {
+		Set<OWLClass> entities = new HashSet<>(o.getClassesInSignature(Imports.INCLUDED));
+		for (OWLClass e : entities) {
+			Set<OWLClass> reasonedClasses = ontologyImporter.getSubClasses(r, e, true, true);
+			reasonedClasses.remove(o.getOWLOntologyManager().getOWLDataFactory().getOWLNothing());
+			Set<OWLClass> queriedClasses = querySubClasses(o, e, true, true);
+			queriedClasses.remove(o.getOWLOntologyManager().getOWLDataFactory().getOWLNothing());
+
+			printDifference(reasonedClasses, queriedClasses);
+			assertEquals(reasonedClasses.size(), queriedClasses.size());
+
+			for (OWLClass clazz : reasonedClasses) {
+				assertTrue(queriedClasses.contains(clazz));
+			}
+		}
+	}
+
+	@Test
+	void testGetAllSubClasses() throws OWLOntologyCreationException {
+		Set<OWLClass> entities = new HashSet<>(o.getClassesInSignature(Imports.INCLUDED));
+		for (OWLClass e : entities) {
+			Set<OWLClass> reasonedClasses = ontologyImporter.getSubClasses(r, e, false, false);
+			reasonedClasses.remove(o.getOWLOntologyManager().getOWLDataFactory().getOWLNothing());
+			Set<OWLClass> queriedClasses = querySubClasses(o, e, false, false);
+			queriedClasses.remove(o.getOWLOntologyManager().getOWLDataFactory().getOWLNothing());
+
+			printDifference(reasonedClasses, queriedClasses);
+			assertEquals(reasonedClasses.size(), queriedClasses.size());
+
+			for (OWLClass clazz : reasonedClasses) {
+				assertTrue(queriedClasses.contains(clazz));
+			}
+		}
+	}
+
+	@Test
+	void testGetTypes() throws OWLOntologyCreationException {
+		Set<OWLNamedIndividual> entities = new HashSet<>(o.getIndividualsInSignature(Imports.INCLUDED));
+		for (OWLNamedIndividual e : entities) {
+			Set<OWLClass> reasonedTypes = r.getTypes(e, true).getFlattened();
+			Set<OWLClass> queriedTypes = queryTypes(o, e, true);
+
+			printDifference(reasonedTypes, queriedTypes);
+			assertEquals(reasonedTypes.size(), queriedTypes.size());
+
+			for (OWLClass clazz : reasonedTypes) {
+				assertTrue(queriedTypes.contains(clazz));
+			}
+		}
+	}
+
+	@Test
+	void testGetIndividuals() throws OWLOntologyCreationException {
+		Set<OWLClass> entities = new HashSet<>(o.getClassesInSignature(Imports.INCLUDED));
+		for (OWLClass e : entities) {
+			Set<OWLNamedIndividual> reasonedIndvs = ontologyImporter.getInstances(r, e);
+			Set<OWLNamedIndividual> queriedIndvs = queryIndividuals(o, e);
+
+			printDifference(reasonedIndvs, queriedIndvs);
+			assertEquals(reasonedIndvs.size(), queriedIndvs.size());
+
+			for (OWLNamedIndividual indv : reasonedIndvs) {
+				assertTrue(queriedIndvs.contains(indv));
+			}
+		}
+	}
+
+	private Set<OWLClass> querySubClasses(OWLOntology o, OWLClass e, boolean direct, boolean excludeEquivalentClasses) {
+		return querySubClasses(o, e.asOWLClass(), direct, excludeEquivalentClasses, new HashSet<OWLClass>());
+	}
+
+	private Set<OWLClass> querySubClasses(OWLOntology o, OWLClass e, boolean direct, boolean excludeEquivalentClasses,
+			Set<OWLClass> scannedClasses) {
+		Set<OWLSubClassOfAxiom> subClassAxioms = o.getSubClassAxiomsForSuperClass(e);
+		Set<OWLClass> subClasses = subClassAxioms.stream().filter(scoa -> !scoa.getSubClass().isAnonymous())
+				.map(scoa -> scoa.getSubClass().asOWLClass()).collect(Collectors.toSet());
+
+		subClasses.addAll(queryEquivalentClasses(o, e));
+
+		if (!direct) {
+			subClasses.add(e);
+			Set<OWLClass> indepthSubClasses = new HashSet<>();
+			for (OWLClass subclass : subClasses) {
+				if (!scannedClasses.contains(subclass)) {
+					scannedClasses.add(subclass);
+					indepthSubClasses
+							.addAll(querySubClasses(o, subclass, direct, excludeEquivalentClasses, scannedClasses));
+				}
+			}
+			subClasses.addAll(indepthSubClasses);
+		}
+
+		if (excludeEquivalentClasses && e.isClassExpressionLiteral()) {
+			subClasses.remove(e.asOWLClass());
+		}
+
+		return subClasses;
+	}
+
+	private Set<OWLClass> queryEquivalentClasses(OWLOntology o, OWLClassExpression e) {
+		Set<OWLEquivalentClassesAxiom> equivalentClassesAxioms = o.getEquivalentClassesAxioms(e.asOWLClass());
+		Set<OWLClass> eqClasses = new HashSet<>();
+		for (OWLEquivalentClassesAxiom eca : equivalentClassesAxioms) {
+			eqClasses.addAll(eca.getNamedClasses());
+		}
+
+		return eqClasses;
+	}
+
+	private Set<OWLClass> queryTypes(OWLOntology o, OWLNamedIndividual e, boolean direct) {
+		Collection<OWLClassExpression> types = EntitySearcher.getTypes(e, o);
+		return types.stream().filter(type -> !type.isAnonymous()).map(type -> type.asOWLClass())
+				.collect(Collectors.toSet());
+	}
+
+	private Set<OWLNamedIndividual> queryIndividuals(OWLOntology o, OWLClass e) {
+		Set<OWLClass> subClasses = querySubClasses(o, e, false, false);
+		Set<OWLNamedIndividual> indvs = new HashSet<>();
+		for (OWLClass clazz : subClasses) {
+			Collection<OWLIndividual> individuals = EntitySearcher.getIndividuals(clazz, o);
+			for (OWLIndividual indv : individuals) {
+				if (indv instanceof OWLNamedIndividual) {
+					indvs.add((OWLNamedIndividual) indv);
+				}
+			}
+		}
+		return indvs;
+	}
+
+	private void printDifference(Set<?> reasonedResult, Set<?> queriedResult) {
+		if (reasonedResult.size() != queriedResult.size()) {
+			System.out.println("Reasoned: ");
+			for (Object indv : reasonedResult) {
+				System.out.println(indv);
+			}
+
+			System.out.println("Queried: ");
+			for (Object indv : queriedResult) {
+				System.out.println(indv);
+			}
+		}
+	}
+
+}

--- a/src/test/java/ebi/spot/neo4j2owl/N2OProcedureTest.java
+++ b/src/test/java/ebi/spot/neo4j2owl/N2OProcedureTest.java
@@ -106,7 +106,7 @@ public class N2OProcedureTest {
 		N2OImportService importService = new N2OImportService();
 		N2OImportResult importResults = new N2OImportResult();
 		importService.prepareConfig(configUrl, importdir);
-		N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(ontologyUrl, importdir, importResults, true);
+		N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(ontologyUrl, importdir, importResults);
 		File cypherDir = new File(importdir, "transactions");
 		if (!cypherDir.isDirectory()) {
 			cypherDir.mkdir();

--- a/src/test/java/ebi/spot/neo4j2owl/N2OProcedureTest.java
+++ b/src/test/java/ebi/spot/neo4j2owl/N2OProcedureTest.java
@@ -106,7 +106,7 @@ public class N2OProcedureTest {
 		N2OImportService importService = new N2OImportService();
 		N2OImportResult importResults = new N2OImportResult();
 		importService.prepareConfig(configUrl, importdir);
-		N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(ontologyUrl, importdir, importResults);
+		N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(ontologyUrl, importdir, importResults, true);
 		File cypherDir = new File(importdir, "transactions");
 		if (!cypherDir.isDirectory()) {
 			cypherDir.mkdir();

--- a/src/test/resources/test_output/bigtest_config.yaml
+++ b/src/test/resources/test_output/bigtest_config.yaml
@@ -1,0 +1,214 @@
+allow_entities_without_labels: true
+index: false
+testmode: false
+batch: true
+safe_label: loose
+batch_size: 100000000
+relation_type_threshold: 0.95
+represent_values_and_annotations_as_json:
+  iris:
+    - "http://purl.obolibrary.org/obo/IAO_0000115"
+    - "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"
+    - "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"
+    - "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym"
+    - "http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"
+
+neo_node_labelling:
+  - classes:
+      - CL:0011005
+      - RO:0015002 some CL:0011005
+    label: GABAergic
+  - classes:
+      - CL:0000679
+      - RO:0015002 some CL:0000679
+    label: Glutamatergic
+  - classes:
+      - CL:0002453
+      - RO:0015002 some CL:0002453
+    label: OPC
+  - classes:
+      - CL:0000127
+      - RO:0015002 some CL:0000127
+    label: Astrocyte
+  - classes:
+      - CL:0000128
+      - RO:0015002 some CL:0000128
+    label: Oligodendrocyte
+  - classes:
+      - CL:0000115
+      - RO:0015002 some CL:0000115
+    label: Endothelial
+  - classes:
+      - CL:0000359
+      - RO:0015002 some CL:0000359
+    label: SMC
+  - classes:
+      - CL:0000669
+      - RO:0015002 some CL:0000669
+    label: Pericyte
+  - classes:
+      - CL:0000129
+      - RO:0015002 some CL:0000129
+    label: Microglial
+  - classes:
+      - CL:4023051
+      - RO:0015002 some CL:0000129
+    label: VLMC
+  - classes:
+      - CL:4023065
+      - RO:0015002 some CL:4023065
+    label: Meis2
+  - classes:
+      - UBERON:0002616
+      - RO:0015002 some UBERON:0002616
+    label: Brain_Region
+  - classes:
+      - SO:0000704
+      - RO:0015002 some SO:0000704
+    label: Gene
+  - classes:
+      - PCL:0010001
+      - RO:0015002 some PCL:0010001
+    label: Cluster
+  - classes:
+      - PATO:0010006
+      - RO:0015002 some PATO:0010006
+    label: morphology
+  - classes:
+      - PATO:0070033
+      - RO:0015002 some PATO:0070033
+    label: projection
+##Morphological subclasses##
+  - classes:
+      - RO:0000053 some PATO:0070026
+    label: Multipolar
+  - classes:
+      - RO:0000053 some PATO:0070015
+    label: Pyramidal
+#  - classes:
+#      - CL:4023066
+#      - BDSHELP:exemplar_of some CL:4023066
+#    label: Horizontal_pyramidal
+#  - classes:
+#      - CL:4023092
+#      - BDSHELP:exemplar_of some CL:4023092
+#    label: Inverted_pyramidal
+#  - classes:
+#      - CL:4023093
+#      - BDSHELP:exemplar_of some CL:4023093
+#    label: Stellate_pyramidal
+#  - classes:
+#      - CL:4023094
+#      - BDSHELP:exemplar_of some CL:4023094
+#    label: Tufted_pyramidal
+  - classes:
+      - RO:0000053 some PATO:0070019
+    label: Untufted_pyramidal
+  - classes:
+      - RO:0000053 some PATO:0070007
+    label: Martinotti
+  - classes:
+      - RO:0000053 some PATO:0070009
+    label: Fan_Martinotti
+  - classes:
+      - RO:0000053 some PATO:0070008
+    label: T_Martinotti
+#  - classes:
+#      - CL:0000118
+#      - BDSHELP:exemplar_of some CL:0000118
+#    label: Basket
+#  - classes:
+#      - CL:4023088
+#      - BDSHELP:exemplar_of some CL:4023088
+#    label: Large_basket
+#  - classes:
+#      - CL:4023090
+#      - BDSHELP:exemplar_of some CL:4023090
+#    label: Small_basket
+#  - classes:
+#      - CL:4023089
+#      - BDSHELP:exemplar_of some CL:4023089
+#    label: Nest_basket
+  - classes:
+      - RO:0000053 some PATO:0070001
+    label: Neurogliaform
+  - classes:
+      - RO:0000053 some PATO:0070011
+    label: Chandelier
+#  - classes:
+#      - CL:4023077
+#      - BDSHELP:exemplar_of some CL:4023077
+#    label: Bitufted
+  - classes:
+      - RO:0000053 some PATO:0070006
+    label: Bipolar
+##Projection subclasses##
+  - classes:
+      - RO:0000053 some PATO:0070028
+    label: Extratelencephalic
+  - classes:
+      - RO:0000053 some PATO:0070034
+    label: Intratelencephalic
+  - classes:
+      - RO:0000053 some PATO:0070029
+    label: Corticothalamic
+  - classes:
+      - RO:0000053 some PATO:0070030
+    label: Near_projecting
+  - classes:
+      - RO:0000053 some PATO:0070031
+    label: Corticomedulla
+##specific badges##
+  - classes:
+      - RO:0002162 some NCBITaxon:10090
+    label: Mus_musculus
+  - classes:
+      - RO:0002162 some NCBITaxon:9606
+    label: Homo_sapiens
+  - classes:
+      - RO:0002162 some NCBITaxon:9483
+    label: Callithrix_jacchus
+  - classes:
+      - RO:0002100 some UBERON:0000956
+    label: Cerebral_cortex
+  - classes:
+      - RO:0002100 some UBERON:0001384
+    label: Primary_motor_cortex
+  - classes:
+      - RO:0002100 some UBERON:0002771
+    label: MTG
+
+
+curie_map:
+  GITHUB: https://github.com/
+  GITHUBH: http://github.com/
+  PMID: http://www.ncbi.nlm.nih.gov/pubmed/
+  orcid: https://orcid.org/
+  doi: https://doi.org/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  ncbigene: http://www.ncbi.nlm.nih.gov/gene/
+  cc: http://creativecommons.org/ns#
+  pato_rel: http://purl.obolibrary.org/obo/pato#
+  so_rel: http://purl.obolibrary.org/obo/so#
+  ro_rel: http://www.obofoundry.org/ro/ro.owl#
+  owl: http://www.w3.org/2002/07/owl#
+  skos: http://www.w3.org/2004/02/skos/core#
+  ensembl: http://identifiers.org/ensembl/
+  RO: http://purl.obolibrary.org/obo/RO_
+  UBERON: http://purl.obolibrary.org/obo/UBERON_
+  CL: http://purl.obolibrary.org/obo/CL_
+  n2o: http://n2o.neo/custom/
+  ILX: http://uri.interlex.org/base/ilx_
+  NCBITaxon: http://purl.obolibrary.org/obo/NCBITaxon_
+  PR: http://purl.obolibrary.org/obo/PR_
+  SO: http://purl.obolibrary.org/obo/SO_
+  OBI: http://purl.obolibrary.org/obo/OBI_
+  PCL: http://purl.obolibrary.org/obo/PCL_
+
+filters:
+  solr:
+    exclusion:
+      iri_prefix:
+        - http://virtualflybrain.org/reports/VFBc_
+      neo4j_node_label:
+        - Channel


### PR DESCRIPTION
When a pre-reasoned and annotated (facets added) ontology is provided, it is possible to use queries to populate neo4j labels without reasoning. 
This feature reduces memory requirement and and execution time.