### PR TITLE
CSV file postfixes added for side loaded entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
 			<version>2.3.3</version>
-			<scope>provided</scope>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.json/json -->

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>
 			<version>2.3.3</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.json/json -->

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
@@ -17,6 +17,7 @@ public class N2OCSVWriter {
     private final RelationTypeCounter relationTypeCounter;
     private final N2OLog log = N2OLog.getInstance();
     private final N2OImportCSVConfig n2OImportCSVConfig = new N2OImportCSVConfig();
+    private final String csvPostfix;
     public enum CSV_TYPE
     {
         NODES("nodes"), RELATIONSHIPS("relationship");
@@ -26,10 +27,15 @@ public class N2OCSVWriter {
         }
     }
 
-    N2OCSVWriter(N2OImportManager manager, RelationTypeCounter relationTypeCounter, File dir) {
+    N2OCSVWriter(N2OImportManager manager, RelationTypeCounter relationTypeCounter, File dir, String csvPostfix) {
         this.manager = manager;
         this.dir = dir;
         this.relationTypeCounter = relationTypeCounter;
+        if(csvPostfix == null) {
+        	this.csvPostfix = "";
+        }else {
+        	this.csvPostfix = csvPostfix;
+        }
     }
 
     void exportOntologyToCSV() throws N2OException {
@@ -49,20 +55,20 @@ public class N2OCSVWriter {
         Map<String, List<N2OOWLRelationship>> relationships = indexRelationshipsByType();
         Map<String, List<String>> dataout_rel = prepareRelationCSVsForExport(relationships);
         prepareCyperQueries(dataout_rel, CSV_TYPE.RELATIONSHIPS);
-        N2OUtils.writeToFile(getImportDir(), dataout_rel, CSV_TYPE.RELATIONSHIPS);
+        N2OUtils.writeToFile(getImportDir(), dataout_rel, CSV_TYPE.RELATIONSHIPS, csvPostfix);
     }
 
     private void processExportForNodes() throws N2OException {
         Map<String, List<OWLEntity>> entities = indexEntitiesByType();
         Map<String, List<String>> dataout = prepareNodeCSVsForExport(entities);
         prepareCyperQueries(dataout, CSV_TYPE.NODES);
-        N2OUtils.writeToFile(dir, dataout, CSV_TYPE.NODES);
+        N2OUtils.writeToFile(dir, dataout, CSV_TYPE.NODES, csvPostfix);
 
     }
 
     private void prepareCyperQueries(Map<String, List<String>> dataout, CSV_TYPE csv_type) {
         for(String type: dataout.keySet()) {
-            File f = N2OUtils.constructFileHandle(dir, csv_type.name, type);
+            File f = N2OUtils.constructFileHandle(dir, csv_type.name, type, csvPostfix);
             String cypher = constructCypherQuery(csv_type, f);
             this.n2OImportCSVConfig.putImport(cypher, f.getName());
         }
@@ -72,6 +78,9 @@ public class N2OCSVWriter {
         String filename = f.getName();
 
         String type = filename.substring(filename.indexOf("_") + 1).replaceAll(N2OStatic.CSV_EXTENSION, "");
+       	if(!csvPostfix.isEmpty()) {
+    		type = type.replace(csvPostfix + "_" , "");
+    	}
         Integer periodic_commit = N2OConfig.getInstance().getPeriodicCommit();
         String cypher = "USING PERIODIC COMMIT "+periodic_commit+"\n" +
                 "LOAD CSV WITH HEADERS FROM \"file:/"+filename+"\" AS cl\n";

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportService.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportService.java
@@ -25,10 +25,10 @@ public class N2OImportService {
     }
 
     public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
-    	return prepareCSVFilesForImport(url, importdir, importResults, true, null);
+    	return prepareCSVFilesForImport(url, importdir, importResults, true, null, null);
     }
 
-    public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults, Boolean enableReasoning, String annotation_iri) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
+    public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults, Boolean enableReasoning, String annotation_iri, String csvPostfix) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
         logger.log("Loading Ontology");
         OWLOntology o = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(getOntologyIRI(url, importdir));
         logger.log("Size ontology: " + o.getAxiomCount());
@@ -38,7 +38,7 @@ public class N2OImportService {
 
         logger.log("Loading in Database: " + importdir.getAbsolutePath());
 
-        N2OCSVWriter csvWriter = new N2OCSVWriter(ontologyImporter.getImportManager(), ontologyImporter.getRelationTypeCounter(), importdir);
+        N2OCSVWriter csvWriter = new N2OCSVWriter(ontologyImporter.getImportManager(), ontologyImporter.getRelationTypeCounter(), importdir, csvPostfix);
         csvWriter.exportOntologyToCSV();
         return csvWriter;
     }

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImporterRunner.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImporterRunner.java
@@ -14,10 +14,14 @@ public class N2OImporterRunner {
 		File importdir = new File(args[2]);
 		Boolean enableReasoning = true;
 		String annotation_iri = null;
+		String csvPostfix = null;
 
 		if (args.length > 3) {
 			enableReasoning = Boolean.parseBoolean(args[3]);
 			annotation_iri = args[4];
+		}
+		if (args.length > 5) {
+			csvPostfix = args[5];
 		}
 
 		if (config.equals("none")) {
@@ -28,7 +32,7 @@ public class N2OImporterRunner {
 		N2OImportResult importResults = new N2OImportResult();
 		try {
 			importService.prepareConfig(config, importdir);
-			N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(url, importdir, importResults, enableReasoning, annotation_iri);
+			N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(url, importdir, importResults, enableReasoning, annotation_iri, csvPostfix);
 			File cypherDir = new File(importdir, "transactions");
 			if (!cypherDir.isDirectory()) {
 				boolean created = cypherDir.mkdir();

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OUtils.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OUtils.java
@@ -62,11 +62,10 @@ public class N2OUtils {
         }
         return "neo4j2owl_UnknownValue";
     }
-
-
-    public static void writeToFile(File dir, Map<String, List<String>> dataout, N2OCSVWriter.CSV_TYPE nodeclass) throws N2OException {
+    
+    public static void writeToFile(File dir, Map<String, List<String>> dataout, N2OCSVWriter.CSV_TYPE nodeclass, String csvPostfix) throws N2OException {
         for (String type : dataout.keySet()) {
-            File f = constructFileHandle(dir, nodeclass.name, type);
+            File f = constructFileHandle(dir, nodeclass.name, type, csvPostfix);
             try {
                 FileUtils.writeLines(f, dataout.get(type));
             } catch (IOException e) {
@@ -74,9 +73,12 @@ public class N2OUtils {
             }
         }
     }
-
-    static File constructFileHandle(File dir, String nodeclass, String type) {
-        return new File(dir, nodeclass + "_" + type + N2OStatic.CSV_EXTENSION);
+    
+    static File constructFileHandle(File dir, String nodeclass, String type, String namePostfix) {
+    	if(!namePostfix.isEmpty() && !namePostfix.startsWith("_")) {
+    		namePostfix = "_" + namePostfix;
+    	}
+        return new File(dir, nodeclass + namePostfix + "_" + type + N2OStatic.CSV_EXTENSION);
     }
 
     public static String render(OWLClassExpression ce) {


### PR DESCRIPTION
In order to prevent file name conflicts with triplestore sourced ontology (pdb.owl) csv exports and side loaded ontology csv exports, a name postfix support added.