### PR TITLE
Only export relations to CSV support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
 			<version>4.5.6</version>
 		</dependency>
 
+		<!-- delete `provided` for owl2neo4jcsv.jar. Keep it for other jars.  -->
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
 			<artifactId>caffeine</artifactId>

--- a/src/main/java/ebi/spot/neo4j2owl/N2OProcedure.java
+++ b/src/main/java/ebi/spot/neo4j2owl/N2OProcedure.java
@@ -73,10 +73,10 @@ public class N2OProcedure {
 	
 	@SuppressWarnings("unused")
 	@Procedure(mode = Mode.WRITE)
-	public Stream<N2OReturnValue> exportOWLEdges(@Name("relationType") String relationType, @Name("currentChunk") int currentChunk, @Name("limit") int chunkCount) {
+	public Stream<N2OReturnValue> exportOWLEdges(@Name("relationType") String relationType, @Name("currentChunk") Long currentChunk, @Name("limit") Long chunkCount) {
 		logger.resetTimer();
 		N2OExportService exportService = new N2OExportService(db);
-		N2OReturnValue result = exportService.owl2ExportEdges(relationType, currentChunk, chunkCount);
+		N2OReturnValue result = exportService.owl2ExportEdges(relationType, currentChunk.intValue(), chunkCount.intValue());
 		return Stream.of(result);
 	}
 

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
@@ -38,10 +38,21 @@ public class N2OCSVWriter {
         }
     }
 
-    void exportOntologyToCSV() throws N2OException {
-        processExportForNodes();
-        processExportForRelationships();
-    }
+	void exportOntologyToCSV(String exportTypes) throws N2OException {
+		switch (exportTypes) {
+		case "only_nodes":
+			processExportForNodes();
+			break;
+		case "only_edges":
+			processExportForRelationships();
+			break;
+		case "all":
+		default:
+			processExportForNodes();
+            processExportForRelationships();
+            break;
+		}
+	}
 
     public void exportN2OImportConfig(File fileOut) throws IOException {
         n2OImportCSVConfig.saveConfig(fileOut);

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportService.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImportService.java
@@ -25,10 +25,10 @@ public class N2OImportService {
     }
 
     public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
-    	return prepareCSVFilesForImport(url, importdir, importResults, true, null, null);
+    	return prepareCSVFilesForImport(url, importdir, importResults, true, null, null, "all");
     }
 
-    public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults, Boolean enableReasoning, String annotation_iri, String csvPostfix) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
+    public N2OCSVWriter prepareCSVFilesForImport(String url, File importdir, N2OImportResult importResults, Boolean enableReasoning, String annotation_iri, String csvPostfix, String exportTypes) throws OWLOntologyCreationException, IOException, InterruptedException, ExecutionException, N2OException {
         logger.log("Loading Ontology");
         OWLOntology o = OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(getOntologyIRI(url, importdir));
         logger.log("Size ontology: " + o.getAxiomCount());
@@ -39,7 +39,7 @@ public class N2OImportService {
         logger.log("Loading in Database: " + importdir.getAbsolutePath());
 
         N2OCSVWriter csvWriter = new N2OCSVWriter(ontologyImporter.getImportManager(), ontologyImporter.getRelationTypeCounter(), importdir, csvPostfix);
-        csvWriter.exportOntologyToCSV();
+        csvWriter.exportOntologyToCSV(exportTypes);
         return csvWriter;
     }
 

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OImporterRunner.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OImporterRunner.java
@@ -5,6 +5,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
 public class N2OImporterRunner {
@@ -15,6 +16,7 @@ public class N2OImporterRunner {
 		Boolean enableReasoning = true;
 		String annotation_iri = null;
 		String csvPostfix = null;
+		String exportTypes = "all";
 
 		if (args.length > 3) {
 			enableReasoning = Boolean.parseBoolean(args[3]);
@@ -22,6 +24,13 @@ public class N2OImporterRunner {
 		}
 		if (args.length > 5) {
 			csvPostfix = args[5];
+		}
+		if (args.length > 5) {
+			String[] allowedExportTypes = {"all", "only_nodes", "only_edges"};
+			String exportParam = args[6].strip().toLowerCase();
+			if (Arrays.asList(allowedExportTypes).contains(exportParam)) {
+				exportTypes = exportParam;
+			}
 		}
 
 		if (config.equals("none")) {
@@ -32,7 +41,7 @@ public class N2OImporterRunner {
 		N2OImportResult importResults = new N2OImportResult();
 		try {
 			importService.prepareConfig(config, importdir);
-			N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(url, importdir, importResults, enableReasoning, annotation_iri, csvPostfix);
+			N2OCSVWriter csvWriter = importService.prepareCSVFilesForImport(url, importdir, importResults, enableReasoning, annotation_iri, csvPostfix, exportTypes);
 			File cypherDir = new File(importdir, "transactions");
 			if (!cypherDir.isDirectory()) {
 				boolean created = cypherDir.mkdir();


### PR DESCRIPTION
Support to export only the relations (not Nodes) to CSV added. Allowed values for this parameter is: `only_nodes`, `only_edges` and `all`

Parameters of `exportOWLEdges` procedure changed from `int` to `Long` to cope with the error:

```
type `int` cannot be converted to a Neo4j type: Don't know how to map `int` to the Neo4j Type System.
```