### PR TITLE
Fix #407: keep parallel relationships distinct on CSV import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,8 @@
 		<!-- https://mvnrepository.com/artifact/org.semanticweb.elk/elk-reasoner -->
 		<dependency>
 			<groupId>org.semanticweb.elk</groupId>
-			<artifactId>elk-owlapi4</artifactId>
-			<version>0.5.0-SNAPSHOT</version>
+			<artifactId>elk-owlapi</artifactId>
+			<version>0.4.3</version>
 			<exclusions>
 				<exclusion>
 					<groupId>net.sourceforge.owlapi</groupId>
@@ -147,19 +147,6 @@
 
 	</dependencies>
 
-	<repositories>
-		<repository>
-			<!-- the repository for snapshot dependencies -->
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</repository>
-	</repositories>
 
 	<build>
 		<testSourceDirectory>src/test/java</testSourceDirectory>

--- a/src/main/java/ebi/spot/neo4j2owl/N2OStatic.java
+++ b/src/main/java/ebi/spot/neo4j2owl/N2OStatic.java
@@ -72,7 +72,7 @@ public class N2OStatic {
     }
 
     public static boolean isN2OBuiltInProperty(OWLEntity property) {
-        return property.equals(abp(ATT_LABEL)) || property.equals(abp(ATT_SAFE_LABEL)) || property.equals(abp(ATT_QUALIFIED_SAFE_LABEL)) || property.equals(abp(ATT_CURIE)) || property.equals(abp(ATT_SHORT_FORM)) || property.equals(abp(ATT_IRI)) || property.equals(abp(ATT_NODE_TYPE));
+        return property.equals(abp(ATT_LABEL)) || property.equals(abp(ATT_SAFE_LABEL)) || property.equals(abp(ATT_QUALIFIED_SAFE_LABEL)) || property.equals(abp(ATT_CURIE)) || property.equals(abp(ATT_SHORT_FORM)) || property.equals(abp(ATT_IRI)) || property.equals(abp(ATT_NODE_TYPE)) || property.equals(abp(ATT_EDGE_SIG));
     }
 
     private static OWLEntity abp(String s) {

--- a/src/main/java/ebi/spot/neo4j2owl/N2OStatic.java
+++ b/src/main/java/ebi/spot/neo4j2owl/N2OStatic.java
@@ -26,6 +26,10 @@ public class N2OStatic {
     public static final String ATT_IRI = "iri";
     public static final String ATT_SHORT_FORM = "short_form";
     public static final String ATT_NODE_TYPE = "type";
+    // Internal per-edge load key used to keep parallel relationships distinct on
+    // import (issue #407). Treated as built-in so it is never re-exported as an
+    // ontology annotation or re-applied via a SET clause.
+    public static final String ATT_EDGE_SIG = "edge_sig";
 
     public static final String ANNOTATION_DELIMITER  = "~|~|~";
     public static final String ANNOTATION_DELIMITER_ESCAPED  = "\\~\\|\\~\\|\\~";
@@ -64,7 +68,7 @@ public class N2OStatic {
     }
 
     public static boolean isN2OBuiltInProperty(String property) {
-        return property.equals(ATT_LABEL) || property.equals(ATT_SAFE_LABEL) || property.equals(ATT_QUALIFIED_SAFE_LABEL) || property.equals(ATT_CURIE) || property.equals(ATT_SHORT_FORM) || property.equals(ATT_IRI) || property.equals(ATT_NODE_TYPE);
+        return property.equals(ATT_LABEL) || property.equals(ATT_SAFE_LABEL) || property.equals(ATT_QUALIFIED_SAFE_LABEL) || property.equals(ATT_CURIE) || property.equals(ATT_SHORT_FORM) || property.equals(ATT_IRI) || property.equals(ATT_NODE_TYPE) || property.equals(ATT_EDGE_SIG);
     }
 
     public static boolean isN2OBuiltInProperty(OWLEntity property) {

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
@@ -365,7 +365,9 @@ public class N2OCSVWriter {
      * @return a lowercase hexadecimal SHA-1 digest
      */
     private String edgeSignature(String type, String rowBody) {
-        String material = type + "" + rowBody;
+        // Join with NUL, which cannot occur in a relationship type or a CSV row,
+        // so the type/row boundary is unambiguous and cannot induce collisions.
+        String material = type + '\0' + rowBody;
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-1");
             byte[] digest = md.digest(material.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
+++ b/src/main/java/ebi/spot/neo4j2owl/importer/N2OCSVWriter.java
@@ -8,6 +8,9 @@ import org.semanticweb.owlapi.model.OWLEntity;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 public class N2OCSVWriter {
@@ -97,8 +100,11 @@ public class N2OCSVWriter {
                 "LOAD CSV WITH HEADERS FROM \"file:/"+filename+"\" AS cl\n";
         switch(csv_type) {
             case RELATIONSHIPS:
+                // Include the per-row edge signature in the MERGE key so that parallel
+                // relationships of the same type between the same pair of nodes are kept
+                // distinct rather than collapsed onto a single edge (issue #407).
                 cypher+="MATCH (s:Entity { iri: cl.start}),(e:Entity { iri: cl.end})\n" +
-                        "MERGE (s)-[r:" + type + "]->(e) " + uncomposedSetClauses("cl", "r", manager.getHeadersForRelationships(type));
+                        "MERGE (s)-[r:" + type + " { edge_sig: cl.edge_sig }]->(e) " + uncomposedSetClauses("cl", "r", manager.getHeadersForRelationships(type));
                 break;
             case NODES:
                 cypher+= "MERGE (n:Entity { iri: cl.iri }) " + uncomposedSetClauses("cl", "n", manager.getHeadersForNodes(type)) + " SET n :" + type;
@@ -218,6 +224,10 @@ public class N2OCSVWriter {
                 sb.append(nodeindex.get(e.getStart()).getIri()).append(",");
                 sb.append(nodeindex.get(e.getEnd()).getIri()).append(",");
                 //sb.append(e.getRelationId());
+                // Stable per-row signature over (type, sorted property values, start, end).
+                // Identical rows hash identically (structural edges still dedup); rows that
+                // differ in any property get distinct signatures and survive the MERGE.
+                sb.append(edgeSignature(type, sb.toString())).append(",");
                 String s = sb.toString();
                 csvout.add(s.substring(0, s.length() - 1));
             }
@@ -337,11 +347,38 @@ public class N2OCSVWriter {
         for (String column : columns_sorted) {
             sb.append(column).append(",");
         }
-        sb.append("start,").append("end");
+        sb.append("start,").append("end,").append("edge_sig");
         //sb.append("type");
         return sb.toString();
     }
 
-
+    /**
+     * Compute a stable signature for a single relationship row so that the load-time
+     * MERGE can keep parallel edges distinct (issue #407). The signature is a SHA-1
+     * hash over the relationship type and the already-serialised row body (sorted
+     * property cells followed by start and end IRIs). Two rows with identical content
+     * hash to the same value and are deduplicated on import; rows differing in any
+     * property value get distinct signatures and survive as separate edges.
+     *
+     * @param type    the relationship type
+     * @param rowBody the serialised CSV row up to and including the end IRI
+     * @return a lowercase hexadecimal SHA-1 digest
+     */
+    private String edgeSignature(String type, String rowBody) {
+        String material = type + "" + rowBody;
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] digest = md.digest(material.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(Character.forDigit((b >> 4) & 0xF, 16));
+                hex.append(Character.forDigit(b & 0xF, 16));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            // SHA-1 is part of every JRE; fall back to a stable string hash if absent.
+            return Integer.toHexString(material.hashCode());
+        }
+    }
 
 }

--- a/src/test/java/ebi/spot/neo4j2owl/N2OProcedureTest.java
+++ b/src/test/java/ebi/spot/neo4j2owl/N2OProcedureTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.neo4j.driver.Config;
@@ -67,6 +68,15 @@ public class N2OProcedureTest {
 		try (Session session = driver.session()) {
 			session.run("MATCH (n) DETACH DELETE n");
 		}
+	}
+
+	@BeforeEach
+	void resetConfig() {
+		// N2OConfig is a process-wide singleton that prepareConfig mutates rather than
+		// replaces. In production each import is its own process, but the test suite
+		// shares one JVM, so reset it between methods to stop one test's config (e.g.
+		// smalltest's nic: node labelling) leaking into another's import.
+		N2OConfig.resetConfig();
 	}
 
 	@Test
@@ -204,7 +214,10 @@ public class N2OProcedureTest {
 			assertEquals("", resMap.get("extraInfo"));
 			assertEquals(16, session.run("MATCH (n:Class) RETURN count(n) AS count").next().get("count").asInt());
 
-			String ontologyString = (String) resMapExport.get("o");
+			// exportOWL() returns the ontology as chunked List<String> (N2OReturnValue.o);
+			// join the chunks rather than casting the list to String.
+			@SuppressWarnings("unchecked")
+			String ontologyString = String.join("", (java.util.List<String>) resMapExport.get("o"));
 			OWLOntologyManager man1 = OWLManager.createOWLOntologyManager();
 			OWLOntologyManager man2 = OWLManager.createOWLOntologyManager();
 			OWLOntology o_orginal = man1.loadOntologyFromOntologyDocument(IRI.create(ontologyUrl));

--- a/src/test/java/ebi/spot/neo4j2owl/N2OProcedureTest.java
+++ b/src/test/java/ebi/spot/neo4j2owl/N2OProcedureTest.java
@@ -131,6 +131,57 @@ public class N2OProcedureTest {
 		}
 	}
 
+	/**
+	 * Regression test for issue #407: the CSV importer must keep parallel
+	 * relationships of the same type between the same pair of nodes distinct
+	 * rather than collapsing them onto a single edge whose properties overwrite
+	 * each other. Exercises the full owl2Import path (CSV write + LOAD CSV MERGE)
+	 * over a fixture that encodes both reported reproductions.
+	 */
+	@Test
+	public void issue407ParallelEdgesSurvive() throws Exception {
+		String ontologyUrl = Objects.requireNonNull(getClass().getClassLoader().getResource("issue407.owl")).toURI()
+				.toURL().toString();
+		String configUrl = Objects.requireNonNull(getClass().getClassLoader().getResource("issue407-config.yaml"))
+				.toURI().toURL().toString();
+
+		try (Session session = driver.session()) {
+			session.run(String.format("CALL ebi.spot.neo4j2owl.owl2Import('%s','%s')", ontologyUrl, configUrl))
+					.consume();
+
+			// Case A: all four database_cross_reference accessions survive, including
+			// the three to the same DoOR Site that previously collapsed onto one edge.
+			assertEquals("all four xref edges should survive", 4L, count(session,
+					"MATCH (:Class {short_form:'FBbt_00067011'})-[r:database_cross_reference]->() RETURN count(r) AS count"));
+			assertEquals("three parallel xref edges to the same Site should survive", 3L, count(session,
+					"MATCH (:Class {short_form:'FBbt_00067011'})-[r:database_cross_reference]->({short_form:'DoOR'}) RETURN count(r) AS count"));
+			Set<String> accessions = new HashSet<>(session.run(
+					"MATCH (:Class {short_form:'FBbt_00067011'})-[r:database_cross_reference]->({short_form:'DoOR'}) "
+							+ "UNWIND r.accession AS a RETURN collect(DISTINCT a) AS accs")
+					.next().get("accs").asList(v -> v.asString()).stream().collect(Collectors.toSet()));
+			assertEquals("no accession should be overwritten",
+					new HashSet<>(java.util.Arrays.asList("DoOR:Or65a", "DoOR:Or65b", "DoOR:Or65c")), accessions);
+
+			// Case B: definition and synonym references to the same publication stay
+			// distinct, and the definition edge carries no synonym typing/value.
+			assertEquals("def and syn references to one pub should be two edges", 2L, count(session,
+					"MATCH (:Class {short_form:'FBbt_00049999'})-[r:has_reference]->({short_form:'FBrf0224194'}) RETURN count(r) AS count"));
+			org.neo4j.driver.Record defRec = session.run(
+					"MATCH (:Class {short_form:'FBbt_00049999'})-[r:has_reference]->({short_form:'FBrf0224194'}) "
+							+ "WHERE 'def' IN r.typ RETURN r.has_synonym_type AS hst, r.value AS value").next();
+			assertTrue("definition edge must not carry a synonym type", defRec.get("hst").isNull());
+			assertTrue("definition edge must not carry a synonym value", defRec.get("value").isNull());
+
+			// Systemic: no has_reference edge carries synonym typing on a non-syn edge.
+			assertEquals("no contaminated reference edges should remain", 0L, count(session,
+					"MATCH ()-[r:has_reference]->() WHERE r.has_synonym_type IS NOT NULL AND NOT ('syn' IN r.typ) RETURN count(r) AS count"));
+		}
+	}
+
+	private long count(Session session, String query) {
+		return session.run(query).next().get("count").asLong();
+	}
+
 	@Test
 	public void owl2Export() throws Exception {
 		// String ontologyUrl = test_resources_web + "smalltest.owl";

--- a/src/test/resources/issue407-config.yaml
+++ b/src/test/resources/issue407-config.yaml
@@ -1,0 +1,6 @@
+allow_entities_without_labels: true
+testmode: true
+batch: true
+safe_label: loose
+batch_size: 100000000
+relation_type_threshold: 0.66

--- a/src/test/resources/issue407.owl
+++ b/src/test/resources/issue407.owl
@@ -1,0 +1,197 @@
+<?xml version="1.0"?>
+<!--
+  Regression fixture for issue #407: neo4j2owl CSV import collapses parallel
+  relationships. Two reproductions are encoded:
+
+  Case A (dropped xref accessions): FBbt_00067011 carries three
+  database_cross_reference (oboInOwl#hasDbXref) assertions to the SAME Site node
+  (DoOR), each with a different accession axiom annotation, plus one to a second
+  Site (FlyBrain_NDB). Before the fix the three DoOR edges collapse to one and
+  two accessions are lost.
+
+  Case B (contaminated synonym/definition references): FBbt_00049999 carries two
+  has_reference (dcterms:references) assertions to the SAME publication
+  (FBrf0224194): one typed def, one typed syn with a synonym value and a
+  has_synonym_type. Before the fix these collapse into a single edge whose typ,
+  value and has_synonym_type are mixed from different sources.
+-->
+<Ontology xmlns="http://www.w3.org/2002/07/owl#"
+     xml:base="http://purl.obolibrary.org/obo/issue407.owl"
+     ontologyIRI="http://purl.obolibrary.org/obo/issue407.owl"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+    <Prefix name="xsd" IRI="http://www.w3.org/2001/XMLSchema#"/>
+    <Prefix name="rdfs" IRI="http://www.w3.org/2000/01/rdf-schema#"/>
+
+    <!-- Subjects -->
+    <Declaration>
+        <Class IRI="http://purl.obolibrary.org/obo/FBbt_00067011"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="http://purl.obolibrary.org/obo/FBbt_00049999"/>
+    </Declaration>
+
+    <!-- Cross-reference target Sites -->
+    <Declaration>
+        <NamedIndividual IRI="http://virtualflybrain.org/data/DoOR"/>
+    </Declaration>
+    <Declaration>
+        <NamedIndividual IRI="http://virtualflybrain.org/data/FlyBrain_NDB"/>
+    </Declaration>
+
+    <!-- Reference target publications -->
+    <Declaration>
+        <NamedIndividual IRI="http://flybase.org/reports/FBrf0224194"/>
+    </Declaration>
+    <Declaration>
+        <NamedIndividual IRI="http://flybase.org/reports/FBrf0193772"/>
+    </Declaration>
+
+    <!-- Relationship annotation properties (IRI-valued -> reified to edges) -->
+    <Declaration>
+        <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+    </Declaration>
+    <Declaration>
+        <AnnotationProperty IRI="http://purl.org/dc/terms/references"/>
+    </Declaration>
+
+    <!-- Axiom-annotation properties (become edge properties) -->
+    <Declaration>
+        <AnnotationProperty IRI="http://n2o.test/accession"/>
+    </Declaration>
+    <Declaration>
+        <AnnotationProperty IRI="http://n2o.test/typ"/>
+    </Declaration>
+    <Declaration>
+        <AnnotationProperty IRI="http://n2o.test/value"/>
+    </Declaration>
+    <Declaration>
+        <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#has_synonym_type"/>
+    </Declaration>
+
+    <!-- Labels: drive safe-label derivation for edge type and property names -->
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00067011</IRI>
+        <Literal>adult olfactory receptor neuron Or65a</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00049999</IRI>
+        <Literal>adult anterior pars intercerebralis</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://www.geneontology.org/formats/oboInOwl#hasDbXref</IRI>
+        <Literal>database_cross_reference</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://purl.org/dc/terms/references</IRI>
+        <Literal>has_reference</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://n2o.test/accession</IRI>
+        <Literal>accession</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://n2o.test/typ</IRI>
+        <Literal>typ</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://n2o.test/value</IRI>
+        <Literal>value</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://www.geneontology.org/formats/oboInOwl#has_synonym_type</IRI>
+        <Literal>has_synonym_type</Literal>
+    </AnnotationAssertion>
+
+    <!-- Case A: three xrefs to DoOR (same Site), one to FlyBrain_NDB -->
+    <AnnotationAssertion>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/accession"/>
+            <Literal>DoOR:Or65a</Literal>
+        </Annotation>
+        <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00067011</IRI>
+        <IRI>http://virtualflybrain.org/data/DoOR</IRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/accession"/>
+            <Literal>DoOR:Or65b</Literal>
+        </Annotation>
+        <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00067011</IRI>
+        <IRI>http://virtualflybrain.org/data/DoOR</IRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/accession"/>
+            <Literal>DoOR:Or65c</Literal>
+        </Annotation>
+        <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00067011</IRI>
+        <IRI>http://virtualflybrain.org/data/DoOR</IRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/accession"/>
+            <Literal>FlyBrain_NDB:10412</Literal>
+        </Annotation>
+        <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00067011</IRI>
+        <IRI>http://virtualflybrain.org/data/FlyBrain_NDB</IRI>
+    </AnnotationAssertion>
+
+    <!-- Case B: definition reference and a synonym reference, both to FBrf0224194 -->
+    <AnnotationAssertion>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/typ"/>
+            <Literal>def</Literal>
+        </Annotation>
+        <AnnotationProperty IRI="http://purl.org/dc/terms/references"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00049999</IRI>
+        <IRI>http://flybase.org/reports/FBrf0224194</IRI>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/typ"/>
+            <Literal>syn</Literal>
+        </Annotation>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/value"/>
+            <Literal>rSMPma</Literal>
+        </Annotation>
+        <Annotation>
+            <AnnotationProperty IRI="http://www.geneontology.org/formats/oboInOwl#has_synonym_type"/>
+            <Literal>BRAIN_NAME_ABV</Literal>
+        </Annotation>
+        <AnnotationProperty IRI="http://purl.org/dc/terms/references"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00049999</IRI>
+        <IRI>http://flybase.org/reports/FBrf0224194</IRI>
+    </AnnotationAssertion>
+    <!-- A second synonym reference to a different publication -->
+    <AnnotationAssertion>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/typ"/>
+            <Literal>syn</Literal>
+        </Annotation>
+        <Annotation>
+            <AnnotationProperty IRI="http://n2o.test/value"/>
+            <Literal>PIa</Literal>
+        </Annotation>
+        <AnnotationProperty IRI="http://purl.org/dc/terms/references"/>
+        <IRI>http://purl.obolibrary.org/obo/FBbt_00049999</IRI>
+        <IRI>http://flybase.org/reports/FBrf0193772</IRI>
+    </AnnotationAssertion>
+</Ontology>


### PR DESCRIPTION
Key the relationship MERGE on a per-row edge_sig (SHA-1 of type, sorted property cells, start and end) so parallel edges of the same type between the same node pair no longer collapse onto one edge with overwriting SETs. Register edge_sig as a built-in property so it is neither re-exported as an OWL annotation nor re-applied via a SET clause. Add a procedure test over both reproductions (xref accession loss; def/syn reference contamination).